### PR TITLE
Fix: Corrected undefined method call in AccreditationController

### DIFF
--- a/app/controllers/AccreditationController.php
+++ b/app/controllers/AccreditationController.php
@@ -36,7 +36,7 @@ class AccreditationController extends BaseController {
         }
 
         // Fetch documents related to this process
-        $documents = $this->documentModel->getDocumentsByProcessId($id);
+        $documents = $this->documentModel->getFilledDocumentsByProcessId($id);
 
         $this->renderView('accreditations/show', [
             'process' => $process,


### PR DESCRIPTION
The `AccreditationController@show` method was attempting to call a non-existent method `getDocumentsByProcessId()` on the `Document` model.

This commit corrects the method call to `getFilledDocumentsByProcessId()`, which is an existing method in the `Document` model designed to fetch documents associated with a specific accreditation process ID.

This change resolves the PHP Fatal error: "Uncaught Error: Call to undefined method Document::getDocumentsByProcessId()".