### PR TITLE
feat: Apply consistent black and white UI theme

### DIFF
--- a/app/views/accreditations/create.php
+++ b/app/views/accreditations/create.php
@@ -1,28 +1,40 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2 class="text-2xl font-semibold text-neon-purple mb-6">Create New Accreditation Process</h2>
-<form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/create" method="POST" class="space-y-6 bg-brand-gray p-6 rounded-lg shadow-lg">
-    <div>
-        <label for="title" class="block text-gray-300 mb-1 font-semibold">Title:</label>
-        <input type="text" id="title" name="title" required value="<?php echo htmlspecialchars($_GET['title'] ?? ''); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-2xl font-bold text-black mb-6">Create New Accreditation Process</h2>
+    <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+        <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/create" method="POST" class="space-y-6">
+            <div>
+                <label for="title" class="block text-sm font-bold text-black mb-1">Title:</label>
+                <input type="text" id="title" name="title" required value="<?php echo htmlspecialchars($_GET['title'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+            </div>
+            <div>
+                <label for="description" class="block text-sm font-bold text-black mb-1">Description:</label>
+                <textarea id="description" name="description" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" rows="4"><?php echo htmlspecialchars($_GET['description'] ?? ''); ?></textarea>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                    <label for="start_date" class="block text-sm font-bold text-black mb-1">Start Date:</label>
+                    <input type="date" id="start_date" name="start_date" value="<?php echo htmlspecialchars($_GET['start_date'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                </div>
+                <div>
+                    <label for="end_date" class="block text-sm font-bold text-black mb-1">End Date:</label>
+                    <input type="date" id="end_date" name="end_date" value="<?php echo htmlspecialchars($_GET['end_date'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                </div>
+            </div>
+            <div>
+                <label for="status" class="block text-sm font-bold text-black mb-1">Status:</label>
+                 <select id="status" name="status" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                    <option value="pending" <?php echo (($_GET['status'] ?? 'pending') === 'pending') ? 'selected' : ''; ?>>Pending</option>
+                    <option value="active" <?php echo (($_GET['status'] ?? '') === 'active') ? 'selected' : ''; ?>>Active</option>
+                    <option value="completed" <?php echo (($_GET['status'] ?? '') === 'completed') ? 'selected' : ''; ?>>Completed</option>
+                    <option value="archived" <?php echo (($_GET['status'] ?? '') === 'archived') ? 'selected' : ''; ?>>Archived</option>
+                </select>
+            </div>
+            <div class="flex items-center justify-between">
+                <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-save mr-2"></i> Create Process</button>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Back to List</a>
+            </div>
+        </form>
     </div>
-    <div>
-        <label for="description" class="block text-gray-300 mb-1 font-semibold">Description:</label>
-        <textarea id="description" name="description" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors" rows="4"><?php echo htmlspecialchars($_GET['description'] ?? ''); ?></textarea>
-    </div>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
-            <label for="start_date" class="block text-gray-300 mb-1 font-semibold">Start Date:</label>
-            <input type="date" id="start_date" name="start_date" value="<?php echo htmlspecialchars($_GET['start_date'] ?? ''); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-        </div>
-        <div>
-            <label for="end_date" class="block text-gray-300 mb-1 font-semibold">End Date:</label>
-            <input type="date" id="end_date" name="end_date" value="<?php echo htmlspecialchars($_GET['end_date'] ?? ''); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-        </div>
-    </div>
-    <div>
-        <label for="status" class="block text-gray-300 mb-1 font-semibold">Status:</label>
-        <input type="text" id="status" name="status" value="<?php echo htmlspecialchars($_GET['status'] ?? 'pending'); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-    </div>
-    <button type="submit" class="w-full md:w-auto bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-6 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-save mr-2"></i> Create Process</button>
-</form>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/accreditations/edit.php
+++ b/app/views/accreditations/edit.php
@@ -1,31 +1,44 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2>Edit Accreditation Process</h2>
-<?php if (isset($data['process'])): ?>
-<form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/update/<?php echo $data['process']['id']; ?>" method="POST">
-    <div>
-        <label for="title">Title:</label>
-        <input type="text" id="title" name="title" value="<?php echo htmlspecialchars($data['process']['title']); ?>" required>
-    </div>
-    <div>
-        <label for="description">Description:</label>
-        <textarea id="description" name="description"><?php echo htmlspecialchars($data['process']['description']); ?></textarea>
-    </div>
-    <div>
-        <label for="start_date">Start Date:</label>
-        <input type="date" id="start_date" name="start_date" value="<?php echo htmlspecialchars($data['process']['start_date']); ?>">
-    </div>
-    <div>
-        <label for="end_date">End Date:</label>
-        <input type="date" id="end_date" name="end_date" value="<?php echo htmlspecialchars($data['process']['end_date']); ?>">
-    </div>
-    <div>
-        <label for="status">Status:</label>
-        <input type="text" id="status" name="status" value="<?php echo htmlspecialchars($data['process']['status']); ?>">
-    </div>
-    <button type="submit" class="bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors"><i class="fas fa-save mr-2"></i> Update Process</button>
-</form>
-<?php else: ?>
-    <p>Process not found.</p>
-<?php endif; ?>
-<p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $data['process']['id']; ?>">Back to Process Details</a></p>
+<div class="container mx-auto px-4 py-8">
+    <?php if (isset($data['process'])): ?>
+        <h2 class="text-2xl font-bold text-black mb-6">Edit Accreditation Process: <?php echo htmlspecialchars($data['process']['title']); ?></h2>
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+            <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/update/<?php echo $data['process']['id']; ?>" method="POST" class="space-y-6">
+                <div>
+                    <label for="title" class="block text-sm font-bold text-black mb-1">Title:</label>
+                    <input type="text" id="title" name="title" value="<?php echo htmlspecialchars($data['process']['title']); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                </div>
+                <div>
+                    <label for="description" class="block text-sm font-bold text-black mb-1">Description:</label>
+                    <textarea id="description" name="description" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" rows="4"><?php echo htmlspecialchars($data['process']['description']); ?></textarea>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <label for="start_date" class="block text-sm font-bold text-black mb-1">Start Date:</label>
+                        <input type="date" id="start_date" name="start_date" value="<?php echo htmlspecialchars($data['process']['start_date']); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                    </div>
+                    <div>
+                        <label for="end_date" class="block text-sm font-bold text-black mb-1">End Date:</label>
+                        <input type="date" id="end_date" name="end_date" value="<?php echo htmlspecialchars($data['process']['end_date']); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                    </div>
+                </div>
+                <div>
+                    <label for="status" class="block text-sm font-bold text-black mb-1">Status:</label>
+                     <select id="status" name="status" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                        <option value="pending" <?php echo (htmlspecialchars($data['process']['status']) === 'pending') ? 'selected' : ''; ?>>Pending</option>
+                        <option value="active" <?php echo (htmlspecialchars($data['process']['status']) === 'active') ? 'selected' : ''; ?>>Active</option>
+                        <option value="completed" <?php echo (htmlspecialchars($data['process']['status']) === 'completed') ? 'selected' : ''; ?>>Completed</option>
+                        <option value="archived" <?php echo (htmlspecialchars($data['process']['status']) === 'archived') ? 'selected' : ''; ?>>Archived</option>
+                    </select>
+                </div>
+                <div class="flex items-center justify-between">
+                    <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-save mr-2"></i> Update Process</button>
+                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $data['process']['id']; ?>" class="text-black hover:underline">Back to Process Details</a>
+                </div>
+            </form>
+        </div>
+    <?php else: ?>
+        <p class="text-black text-center">Process not found.</p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/accreditations/index.php
+++ b/app/views/accreditations/index.php
@@ -1,41 +1,62 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2>All Accreditation Processes</h2>
-<?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
-    <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/showCreateForm">Create New Process</a></p>
-<?php endif; ?>
+<div class="container mx-auto px-4 py-8">
+    <div class="flex justify-between items-center mb-6">
+        <h2 class="text-2xl font-bold text-black">Accreditation Processes</h2>
+        <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
+            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/showCreateForm" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-plus mr-2"></i> Create New Process</a>
+        <?php endif; ?>
+    </div>
 
-<?php if (isset($data['processes']) && !empty($data['processes'])): ?>
-    <table>
-        <thead>
-            <tr>
-                <th>Title</th>
-                <th>Status</th>
-                <th>Start Date</th>
-                <th>End Date</th>
-                <th>Created By</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($data['processes'] as $process): ?>
-                <tr>
-                    <td><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $process['id']; ?>"><?php echo htmlspecialchars($process['title']); ?></a></td>
-                    <td><?php echo htmlspecialchars($process['status']); ?></td>
-                    <td><?php echo htmlspecialchars($process['start_date'] ?? 'N/A'); ?></td>
-                    <td><?php echo htmlspecialchars($process['end_date'] ?? 'N/A'); ?></td>
-                    <td><?php echo htmlspecialchars($process['created_by_name'] ?? 'N/A'); ?></td>
-                    <td>
-                        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $process['id']; ?>">View</a>
-                        <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
-                            | <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/showEditForm/<?php echo $process['id']; ?>">Edit</a>
-                            | <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/delete/<?php echo $process['id']; ?>" data-message="Are you sure you want to delete this process and ALL related data (documents, tasks, comments)? This action cannot be undone." class="delete-confirm-link">Delete</a>
-                        <?php endif; ?>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-<?php else: ?>
-    <p>No accreditation processes found.</p>
-<?php endif; ?>
+    <?php if (isset($data['processes']) && !empty($data['processes'])): ?>
+        <div class="overflow-x-auto">
+            <table class="min-w-full bg-white border border-black rounded-lg shadow-md">
+                <thead class="bg-black text-white">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Title</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Status</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Start Date</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">End Date</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Created By</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    <?php foreach ($data['processes'] as $process): ?>
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black">
+                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $process['id']; ?>" class="text-black hover:underline font-semibold"><?php echo htmlspecialchars($process['title']); ?></a>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black">
+                                <span class="font-medium px-2 py-0.5 rounded-full text-xs
+                                <?php
+                                    switch (strtolower($process['status'] ?? '')) {
+                                        case 'active': echo 'bg-green-100 text-green-800 border border-green-400'; break;
+                                        case 'pending': echo 'bg-yellow-100 text-yellow-800 border border-yellow-400'; break;
+                                        case 'completed': echo 'bg-blue-100 text-blue-800 border border-blue-400'; break;
+                                        case 'archived': echo 'bg-gray-100 text-gray-800 border border-gray-400'; break;
+                                        default: echo 'bg-gray-200 text-gray-800 border border-gray-400';
+                                    }
+                                ?>">
+                                <?php echo htmlspecialchars(ucfirst($process['status'])); ?>
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black"><?php echo htmlspecialchars($process['start_date'] ? date('M d, Y', strtotime($process['start_date'])) : 'N/A'); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black"><?php echo htmlspecialchars($process['end_date'] ? date('M d, Y', strtotime($process['end_date'])) : 'N/A'); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black"><?php echo htmlspecialchars($process['created_by_name'] ?? 'N/A'); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black space-x-2">
+                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $process['id']; ?>" class="text-black hover:underline">View</a>
+                                <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
+                                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/showEditForm/<?php echo $process['id']; ?>" class="text-black hover:underline">Edit</a>
+                                    <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/delete/<?php echo $process['id']; ?>" data-message="Are you sure you want to delete this process and ALL related data (documents, tasks, comments)? This action cannot be undone." class="delete-confirm-link text-red-600 hover:text-red-800 underline">Delete</a>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php else: ?>
+        <p class="text-black">No accreditation processes found.</p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/accreditations/show.php
+++ b/app/views/accreditations/show.php
@@ -1,67 +1,70 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<?php if (isset($data['process'])): ?>
-    <div class="mb-6">
-        <h2 class="text-3xl font-bold text-neon-purple mb-3"><?php echo htmlspecialchars($data['process']['title']); ?></h2>
-        <p class="text-gray-400"><strong class="text-gray-300">Description:</strong> <?php echo nl2br(htmlspecialchars($data['process']['description'] ?? 'N/A')); ?></p>
-        <p class="text-gray-400 mt-1"><strong class="text-gray-300">Status:</strong>
-            <span class="font-medium px-2 py-0.5 rounded-full text-sm
-                <?php
-                    switch (strtolower($data['process']['status'] ?? '')) {
-                        case 'active': echo 'bg-green-600 text-green-100'; break;
-                        case 'pending': echo 'bg-yellow-600 text-yellow-100'; break;
-                        case 'completed': echo 'bg-blue-600 text-blue-100'; break;
-                        case 'archived': echo 'bg-gray-700 text-gray-200'; break;
-                        default: echo 'bg-gray-600 text-gray-100';
-                    }
-                ?>">
-                <?php echo htmlspecialchars(ucfirst($data['process']['status'])); ?>
-            </span>
-        </p>
-        <p class="text-gray-400 mt-1"><strong class="text-gray-300">Start Date:</strong> <?php echo htmlspecialchars($data['process']['start_date'] ?? 'N/A'); ?></p>
-        <p class="text-gray-400 mt-1"><strong class="text-gray-300">End Date:</strong> <?php echo htmlspecialchars($data['process']['end_date'] ?? 'N/A'); ?></p>
-        <p class="text-gray-400 mt-1"><strong class="text-gray-300">Created By:</strong> <?php echo htmlspecialchars($data['process']['created_by_name'] ?? 'N/A'); ?> on <?php echo htmlspecialchars(date('M d, Y', strtotime($data['process']['created_at']))); ?></p>
-    </div>
+<div class="container mx-auto px-4 py-8">
+    <?php if (isset($data['process'])): ?>
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black mb-6">
+            <h2 class="text-3xl font-bold text-black mb-3"><?php echo htmlspecialchars($data['process']['title']); ?></h2>
+            <div class="space-y-2">
+                <p class="text-black"><strong class="font-semibold">Description:</strong> <?php echo nl2br(htmlspecialchars($data['process']['description'] ?? 'N/A')); ?></p>
+                <p class="text-black"><strong class="font-semibold">Status:</strong>
+                    <span class="font-medium px-2 py-0.5 rounded-full text-xs
+                        <?php
+                            switch (strtolower($data['process']['status'] ?? '')) {
+                                case 'active': echo 'bg-green-100 text-green-800 border border-green-400'; break;
+                                case 'pending': echo 'bg-yellow-100 text-yellow-800 border border-yellow-400'; break;
+                                case 'completed': echo 'bg-blue-100 text-blue-800 border border-blue-400'; break;
+                                case 'archived': echo 'bg-gray-100 text-gray-800 border border-gray-400'; break;
+                                default: echo 'bg-gray-200 text-gray-800 border border-gray-400';
+                            }
+                        ?>">
+                        <?php echo htmlspecialchars(ucfirst($data['process']['status'])); ?>
+                    </span>
+                </p>
+                <p class="text-black"><strong class="font-semibold">Start Date:</strong> <?php echo htmlspecialchars($data['process']['start_date'] ? date('M d, Y', strtotime($data['process']['start_date'])) : 'N/A'); ?></p>
+                <p class="text-black"><strong class="font-semibold">End Date:</strong> <?php echo htmlspecialchars($data['process']['end_date'] ? date('M d, Y', strtotime($data['process']['end_date'])) : 'N/A'); ?></p>
+                <p class="text-black"><strong class="font-semibold">Created By:</strong> <?php echo htmlspecialchars($data['process']['created_by_name'] ?? 'N/A'); ?> on <?php echo htmlspecialchars(date('M d, Y', strtotime($data['process']['created_at']))); ?></p>
+            </div>
+        </div>
 
-    <hr class="border-gray-700 my-6">
+        <hr class="border-black my-6">
 
-    <div>
-        <h3 class="text-2xl font-semibold text-gray-200 mb-4">Filled Documents for this Process</h3>
-        <?php // Link to select a template to fill for this process. Accessible by any logged-in user. ?>
-        <p class="mb-4"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/selectTemplate/<?php echo $data['process']['id']; ?>" class="inline-block bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors duration-300"><i class="fas fa-file-alt mr-2"></i> Create New Document from Template</a></p>
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black mb-6">
+            <h3 class="text-xl font-semibold text-black mb-4">Filled Documents for this Process</h3>
+            <p class="mb-4"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/selectTemplate/<?php echo $data['process']['id']; ?>" class="inline-block bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-file-alt mr-2"></i> Create New Document from Template</a></p>
 
-        <?php if (isset($data['documents']) && !empty($data['documents'])): ?>
-            <ul class="space-y-3">
-                <?php foreach ($data['documents'] as $doc): ?>
-                    <li id="doc<?php echo $doc['id'];?>" class="bg-brand-dark p-4 rounded-lg shadow hover:shadow-neon-purple/20 transition-shadow duration-300 flex justify-between items-center">
-                        <div>
-                            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/view/<?php echo $doc['id']; ?>" class="text-lg font-medium text-blue-400 hover:text-blue-300"><?php echo htmlspecialchars($doc['name']); ?></a>
-                            <span class="text-sm text-gray-500 ml-2">(Template: <?php echo htmlspecialchars($doc['template_name']); ?> - Status: <?php echo htmlspecialchars(ucfirst($doc['status'])); ?>)</span>
-                        </div>
-                        <div class="space-x-3 whitespace-nowrap">
-                            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $doc['id']; ?>" class="text-green-400 hover:text-green-300"><i class="fas fa-tasks mr-1"></i> Tasks</a>
-                            <?php if ($doc['user_id'] == ($_SESSION['user_id'] ?? null) || (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser')): ?>
-                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/edit/<?php echo $doc['id']; ?>" class="text-yellow-400 hover:text-yellow-300"><i class="fas fa-edit mr-1"></i> Edit</a>
-                                <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/delete/<?php echo $doc['id']; ?>/<?php echo $data['process']['id']; ?>" data-message="Are you sure you want to delete this document and all its tasks? This action cannot be undone." class="delete-confirm-link text-red-400 hover:text-red-300"><i class="fas fa-trash-alt mr-1"></i> Delete</a>
-                            <?php endif; ?>
-                             <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/showByEntity/document/<?php echo $doc['id']; ?>" class="text-gray-500 hover:text-gray-300"><i class="fas fa-comments mr-1"></i> Comments</a>
-                        </div>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        <?php else: ?>
-            <p class="text-gray-400">No documents found for this process.</p>
-        <?php endif; ?>
-    </div>
+            <?php if (isset($data['documents']) && !empty($data['documents'])): ?>
+                <ul class="space-y-3">
+                    <?php foreach ($data['documents'] as $doc): ?>
+                        <li id="doc<?php echo $doc['id'];?>" class="bg-gray-50 p-4 rounded-md border border-gray-300 hover:shadow-lg transition-shadow duration-300 flex justify-between items-center">
+                            <div>
+                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/view/<?php echo $doc['id']; ?>" class="text-lg font-medium text-black hover:underline"><?php echo htmlspecialchars($doc['name']); ?></a>
+                                <span class="text-sm text-gray-600 ml-2">(Template: <?php echo htmlspecialchars($doc['template_name']); ?> - Status: <?php echo htmlspecialchars(ucfirst($doc['status'])); ?>)</span>
+                            </div>
+                            <div class="space-x-3 whitespace-nowrap">
+                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $doc['id']; ?>" class="text-black hover:underline"><i class="fas fa-tasks mr-1"></i> Tasks</a>
+                                <?php if ($doc['user_id'] == ($_SESSION['user_id'] ?? null) || (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser')): ?>
+                                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/edit/<?php echo $doc['id']; ?>" class="text-black hover:underline"><i class="fas fa-edit mr-1"></i> Edit</a>
+                                    <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/delete/<?php echo $doc['id']; ?>/<?php echo $data['process']['id']; ?>" data-message="Are you sure you want to delete this document and all its tasks? This action cannot be undone." class="delete-confirm-link text-red-600 hover:text-red-800 underline"><i class="fas fa-trash-alt mr-1"></i> Delete</a>
+                                <?php endif; ?>
+                                 <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/showByEntity/document/<?php echo $doc['id']; ?>" class="text-black hover:underline"><i class="fas fa-comments mr-1"></i> Comments</a>
+                            </div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else: ?>
+                <p class="text-black">No documents found for this process.</p>
+            <?php endif; ?>
+        </div>
 
-    <hr class="border-gray-700 my-6">
+        <hr class="border-black my-6">
 
-    <div>
-        <h3 class="text-2xl font-semibold text-gray-200 mb-3">Comments for this Process</h3>
-        <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/showByEntity/process/<?php echo $data['process']['id']; ?>" class="text-gray-400 hover:text-gray-200 underline"><i class="fas fa-comments mr-1"></i> View/Add Comments for Process</a></p>
-    </div>
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+            <h3 class="text-xl font-semibold text-black mb-3">Comments for this Process</h3>
+            <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/showByEntity/process/<?php echo $data['process']['id']; ?>" class="text-black hover:underline"><i class="fas fa-comments mr-1"></i> View/Add Comments for Process</a></p>
+        </div>
 
-    <p class="mt-8"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-neon-purple hover:text-purple-400 font-semibold"><i class="fas fa-arrow-left mr-2"></i>Back to All Processes</a></p>
-<?php else: ?>
-    <p class="text-red-400">Accreditation process not found.</p>
-<?php endif; ?>
+        <p class="mt-8"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline font-semibold"><i class="fas fa-arrow-left mr-2"></i>Back to All Processes</a></p>
+    <?php else: ?>
+        <p class="text-red-600 text-center">Accreditation process not found.</p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/auth/login.php
+++ b/app/views/auth/login.php
@@ -1,15 +1,41 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2>Login</h2>
-<form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/login" method="POST">
-    <div>
-        <label for="email">Email:</label>
-        <input type="email" id="email" name="email" required value="<?php echo htmlspecialchars($_GET['email'] ?? ''); ?>">
+
+<div class="min-h-screen flex flex-col items-center justify-center bg-white py-12 px-4 sm:px-6 lg:px-8">
+    <div class="bg-white p-8 rounded shadow-md w-full max-w-md">
+        <h2 class="text-2xl font-bold text-center text-black mb-6">Login</h2>
+
+        <!-- Placeholder for error/success messages -->
+        <?php if (isset($_GET['error'])): ?>
+            <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4" role="alert">
+                <?php echo htmlspecialchars(urldecode($_GET['error'])); ?>
+            </div>
+        <?php endif; ?>
+        <?php if (isset($_GET['success'])): ?>
+            <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4" role="alert">
+                <?php echo htmlspecialchars(urldecode($_GET['success'])); ?>
+            </div>
+        <?php endif; ?>
+
+        <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/login" method="POST" class="space-y-6">
+            <div>
+                <label for="email" class="block text-sm font-bold text-black mb-1">Email address</label>
+                <input type="email" id="email" name="email" required value="<?php echo htmlspecialchars($_GET['email'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" placeholder="you@example.com">
+            </div>
+            <div>
+                <label for="password" class="block text-sm font-bold text-black mb-1">Password</label>
+                <input type="password" id="password" name="password" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" placeholder="Password">
+            </div>
+            <button type="submit" class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                <i class="fas fa-sign-in-alt mr-2"></i> Login
+            </button>
+        </form>
+        <p class="mt-6 text-center text-sm">
+            Don't have an account?
+            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showRegistrationForm" class="font-medium text-black hover:text-gray-700 underline">
+                Register here
+            </a>
+        </p>
     </div>
-    <div>
-        <label for="password">Password:</label>
-        <input type="password" id="password" name="password" required>
-    </div>
-    <button type="submit" class="bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors"><i class="fas fa-sign-in-alt mr-2"></i> Login</button>
-</form>
-<p>Don't have an account? <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showRegistrationForm" class="text-neon-purple hover:text-purple-400">Register here</a>.</p>
+</div>
+
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/auth/register.php
+++ b/app/views/auth/register.php
@@ -1,30 +1,58 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2 class="text-2xl font-semibold text-neon-purple mb-6 text-center">Register</h2>
-<form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/register" method="POST" class="max-w-md mx-auto bg-brand-gray p-8 rounded-lg shadow-xl">
-    <div class="mb-4">
-        <label for="name" class="block text-gray-300 mb-1 font-semibold">Name:</label>
-        <input type="text" id="name" name="name" required value="<?php echo htmlspecialchars($_GET['name'] ?? ''); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
+
+<div class="min-h-screen flex flex-col items-center justify-center bg-white py-12 px-4 sm:px-6 lg:px-8">
+    <div class="bg-white p-8 rounded shadow-md w-full max-w-md">
+        <h2 class="text-2xl font-bold text-center text-black mb-6">Register</h2>
+
+        <!-- Placeholder for error/success messages -->
+        <?php if (isset($_GET['error'])): ?>
+            <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4" role="alert">
+                <?php echo htmlspecialchars(urldecode($_GET['error'])); ?>
+            </div>
+        <?php endif; ?>
+        <?php if (isset($_GET['success'])): ?>
+            <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4" role="alert">
+                <?php echo htmlspecialchars(urldecode($_GET['success'])); ?>
+            </div>
+        <?php endif; ?>
+
+        <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/register" method="POST" class="space-y-4">
+            <div>
+                <label for="name" class="block text-sm font-bold text-black mb-1">Name</label>
+                <input type="text" id="name" name="name" required value="<?php echo htmlspecialchars($_GET['name'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" placeholder="Your Name">
+            </div>
+            <div>
+                <label for="email" class="block text-sm font-bold text-black mb-1">Email address</label>
+                <input type="email" id="email" name="email" required value="<?php echo htmlspecialchars($_GET['email'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" placeholder="you@example.com">
+            </div>
+            <div>
+                <label for="password" class="block text-sm font-bold text-black mb-1">Password</label>
+                <input type="password" id="password" name="password" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" placeholder="Password">
+            </div>
+
+            <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): // Only logged-in superuser can set role  ?>
+            <div>
+                <label for="role" class="block text-sm font-bold text-black mb-1">Role</label>
+                <select id="role" name="role" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                    <option value="regular" <?php echo (isset($_GET['role']) && $_GET['role'] === 'regular') ? 'selected' : ''; ?>>Regular</option>
+                    <option value="superuser" <?php echo (isset($_GET['role']) && $_GET['role'] === 'superuser') ? 'selected' : ''; ?>>Superuser</option>
+                </select>
+            </div>
+            <?php else: ?>
+                <input type="hidden" name="role" value="regular">
+            <?php endif; ?>
+
+            <button type="submit" class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                <i class="fas fa-user-plus mr-2"></i> Register
+            </button>
+        </form>
+        <p class="mt-6 text-center text-sm">
+            Already have an account?
+            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showLoginForm" class="font-medium text-black hover:text-gray-700 underline">
+                Login here
+            </a>
+        </p>
     </div>
-    <div class="mb-4">
-        <label for="email" class="block text-gray-300 mb-1 font-semibold">Email:</label>
-        <input type="email" id="email" name="email" required value="<?php echo htmlspecialchars($_GET['email'] ?? ''); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-    </div>
-    <div class="mb-6">
-        <label for="password" class="block text-gray-300 mb-1 font-semibold">Password:</label>
-        <input type="password" id="password" name="password" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-    </div>
-    <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): // Only logged-in superuser can set role  ?>
-    <div class="mb-4">
-        <label for="role" class="block text-gray-300 mb-1 font-semibold">Role:</label>
-        <select id="role" name="role" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-            <option value="regular" <?php echo (isset($_GET['role']) && $_GET['role'] === 'regular') ? 'selected' : ''; ?>>Regular</option>
-            <option value="superuser" <?php echo (isset($_GET['role']) && $_GET['role'] === 'superuser') ? 'selected' : ''; ?>>Superuser</option>
-        </select>
-    </div>
-    <?php else: ?>
-        <input type="hidden" name="role" value="regular">
-    <?php endif; ?>
-    <button type="submit" class="w-full bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-4 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-user-plus mr-2"></i> Register</button>
-</form>
-<p class="text-center mt-6">Already have an account? <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showLoginForm" class="text-neon-purple hover:text-purple-400 font-semibold">Login here</a>.</p>
+</div>
+
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/comments/show_by_entity.php
+++ b/app/views/comments/show_by_entity.php
@@ -1,38 +1,42 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
+<div class="container mx-auto px-4 py-8">
+    <?php if (isset($data['entity_type_display']) && isset($data['entity_name_display']) && isset($data['entity_type']) && isset($data['entity_id']) && isset($data['back_link'])): ?>
+        <h3 class="text-2xl font-bold text-black mb-6">Comments/Feedback for <?php echo htmlspecialchars($data['entity_type_display']); ?>: <span class="font-semibold">"<?php echo htmlspecialchars($data['entity_name_display']); ?>"</span></h3>
 
-<?php if (isset($data['entity_type_display']) && isset($data['entity_name_display']) && isset($data['entity_type']) && isset($data['entity_id']) && isset($data['back_link'])): ?>
-    <h3 class="text-2xl font-semibold text-neon-purple mb-4">Comments/Feedback for <?php echo htmlspecialchars($data['entity_type_display']); ?>: <span class="text-gray-200">"<?php echo htmlspecialchars($data['entity_name_display']); ?>"</span></h3>
-
-    <div id="comments-list-container" class="space-y-4 mb-6">
-        <?php if (isset($data['comments']) && !empty($data['comments'])): ?>
-            <?php foreach ($data['comments'] as $comment): ?>
-                <div class="bg-brand-dark p-4 rounded-lg shadow">
-                    <p class="text-gray-300"><?php echo nl2br(htmlspecialchars($comment['comment_text'])); ?></p>
-                    <p class="text-xs text-gray-500 mt-2">
-                        By: <strong><?php echo htmlspecialchars($comment['user_name'] ?? 'Anonymous'); ?></strong>
-                        on <em><?php echo htmlspecialchars(date("M d, Y H:i", strtotime($comment['created_at']))); ?></em>
-                        <?php if (isset($_SESSION['user_id']) && ( (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser') || $_SESSION['user_id'] == $comment['user_id'])): ?>
-                            <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/delete/<?php echo $comment['id']; ?>/<?php echo $data['entity_type']; ?>/<?php echo $data['entity_id']; ?>" data-message="Are you sure you want to delete this comment?" class="delete-confirm-link text-red-400 hover:text-red-600 ml-2"><i class="fas fa-times-circle mr-1"></i> Delete</a>
-                        <?php endif; ?>
-                    </p>
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black mb-6">
+            <h4 class="text-xl font-semibold text-black mb-3">Add a New Comment:</h4>
+            <form id="ajax-comment-form" action="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/create/<?php echo $data['entity_type']; ?>/<?php echo $data['entity_id']; ?>" method="POST">
+                <div>
+                    <textarea name="comment_text" rows="3" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" placeholder="Write your comment..." required></textarea>
                 </div>
-            <?php endforeach; ?>
-        <?php else: ?>
-            <p class="text-gray-400">No comments yet for this <?php echo htmlspecialchars($data['entity_type_display']); ?>.</p>
-        <?php endif; ?>
-    </div>
-
-    <h4 class="text-xl font-semibold text-gray-200 mt-6 mb-3">Add a New Comment:</h4>
-    <form id="ajax-comment-form" action="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/create/<?php echo $data['entity_type']; ?>/<?php echo $data['entity_id']; ?>" method="POST" class="bg-brand-gray p-4 rounded-lg shadow">
-        <div>
-            <textarea name="comment_text" rows="4" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors" placeholder="Write your comment..."></textarea>
+                <button type="submit" class="mt-2 bg-black text-white px-3 py-1.5 rounded-md text-sm hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"><i class="fas fa-paper-plane mr-2"></i>Submit Comment</button>
+            </form>
         </div>
-        <button type="submit" class="mt-3 w-full md:w-auto bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-paper-plane mr-2"></i>Submit Comment</button>
-    </form>
-    <p class="mt-6"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?><?php echo htmlspecialchars($data['back_link']); // Controller provides path like 'controller/action/param' ?>" class="text-neon-purple hover:text-purple-400"><i class="fas fa-arrow-left mr-2"></i>Back to <?php echo htmlspecialchars($data['entity_type_display']); ?></a></p>
-<?php else: ?>
-    <p class="text-red-400">Error: Entity information for comments is missing.</p>
-    <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>home/index" class="text-neon-purple hover:text-purple-400">Return to Dashboard</a></p>
-<?php endif; ?>
 
+        <h4 class="text-xl font-semibold text-black mb-4">Existing Comments:</h4>
+        <div id="comments-list-container" class="space-y-4">
+            <?php if (isset($data['comments']) && !empty($data['comments'])): ?>
+                <?php foreach ($data['comments'] as $comment): ?>
+                    <div class="bg-white p-4 rounded-lg shadow border border-black">
+                        <p class="font-semibold text-black text-sm"><?php echo htmlspecialchars($comment['user_name'] ?? 'Anonymous'); ?></p>
+                        <p class="text-xs text-gray-500 mb-1"><?php echo htmlspecialchars(date("M d, Y H:i", strtotime($comment['created_at']))); ?></p>
+                        <p class="text-black text-sm whitespace-pre-wrap"><?php echo nl2br(htmlspecialchars($comment['comment_text'])); ?></p>
+                        <?php if (isset($_SESSION['user_id']) && ( (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser') || $_SESSION['user_id'] == $comment['user_id'])): ?>
+                            <div class="mt-2 text-right">
+                                <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/delete/<?php echo $comment['id']; ?>/<?php echo $data['entity_type']; ?>/<?php echo $data['entity_id']; ?>" data-message="Are you sure you want to delete this comment?" class="delete-confirm-link text-red-600 hover:text-red-800 underline text-xs ml-2"><i class="fas fa-times-circle mr-1"></i> Delete</a>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                <?php endforeach; ?>
+            <?php else: ?>
+                <p class="text-gray-600 text-sm">No comments yet for this <?php echo htmlspecialchars($data['entity_type_display']); ?>.</p>
+            <?php endif; ?>
+        </div>
+
+        <p class="mt-8"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?><?php echo htmlspecialchars($data['back_link']); // Controller provides path like 'controller/action/param' ?>" class="text-black hover:underline"><i class="fas fa-arrow-left mr-2"></i>Back to <?php echo htmlspecialchars($data['entity_type_display']); ?></a></p>
+    <?php else: ?>
+        <p class="text-red-600 text-center">Error: Entity information for comments is missing.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>home/index" class="text-black hover:underline">Return to Dashboard</a></p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/document_templates/create.php
+++ b/app/views/document_templates/create.php
@@ -1,26 +1,28 @@
 <?php // app/views/document_templates/create.php
 require_once __DIR__ . '/../layouts/header.php'; ?>
-<div class="container mx-auto p-4">
-    <h2 class="text-3xl font-bold text-neon-purple mb-6">Create New Document Template</h2>
-    <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/create" method="POST" class="space-y-6 bg-brand-gray p-6 rounded-lg shadow-lg">
-        <div>
-            <label for="name" class="block text-sm font-medium text-gray-300 mb-1">Template Name:</label>
-            <input type="text" id="name" name="name" value="<?php echo htmlspecialchars($data['name'] ?? ''); ?>" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-        </div>
-        <div>
-            <label for="description" class="block text-sm font-medium text-gray-300 mb-1">Description:</label>
-            <textarea id="description" name="description" rows="3" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors"><?php echo htmlspecialchars($data['description'] ?? ''); ?></textarea>
-        </div>
-        <div>
-            <label for="fields_definition" class="block text-sm font-medium text-gray-300 mb-1">Fields Definition (JSON):</label>
-            <textarea id="fields_definition" name="fields_definition" rows="10" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded font-mono text-sm focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors"><?php echo htmlspecialchars($data['fields_definition'] ?? '[{"name": "field_name", "label": "Field Label", "type": "text", "required": false, "placeholder": "Enter value"}, {"name": "another_field", "label": "Another Field", "type": "textarea"}]'); ?></textarea>
-            <p class="text-xs text-gray-500 mt-1">Enter a JSON array defining the fields. E.g., `[{"name": "title", "label": "Title", "type": "text"}, {"name": "content", "label": "Content", "type": "textarea"}]`</p>
-            <p class="text-xs text-gray-500 mt-1">Supported types: `text`, `textarea`, `date`, `number`, `checkbox`, `select` (provide `options` array for select).</p>
-        </div>
-        <div>
-            <button type="submit" class="bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-6 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-save mr-2"></i> Create Template</button>
-            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/index" class="ml-4 text-gray-400 hover:text-gray-200">Cancel</a>
-        </div>
-    </form>
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-2xl font-bold text-black mb-6">Create New Document Template</h2>
+    <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+        <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/create" method="POST" class="space-y-6">
+            <div>
+                <label for="name" class="block text-sm font-bold text-black mb-1">Template Name:</label>
+                <input type="text" id="name" name="name" value="<?php echo htmlspecialchars($data['name'] ?? ''); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+            </div>
+            <div>
+                <label for="description" class="block text-sm font-bold text-black mb-1">Description:</label>
+                <textarea id="description" name="description" rows="3" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black"><?php echo htmlspecialchars($data['description'] ?? ''); ?></textarea>
+            </div>
+            <div>
+                <label for="fields_definition" class="block text-sm font-bold text-black mb-1">Fields Definition (JSON):</label>
+                <textarea id="fields_definition" name="fields_definition" rows="10" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black font-mono text-sm"><?php echo htmlspecialchars($data['fields_definition'] ?? '[{"name": "field_name", "label": "Field Label", "type": "text", "required": false, "placeholder": "Enter value"}, {"name": "another_field", "label": "Another Field", "type": "textarea"}]'); ?></textarea>
+                <p class="text-xs text-gray-600 mt-1">Enter a JSON array defining the fields. E.g., `[{"name": "title", "label": "Title", "type": "text"}, {"name": "content", "label": "Content", "type": "textarea"}]`</p>
+                <p class="text-xs text-gray-600 mt-1">Supported types: `text`, `textarea`, `date`, `number`, `checkbox`, `select` (provide `options` array for select).</p>
+            </div>
+            <div class="flex items-center justify-between">
+                <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-save mr-2"></i> Create Template</button>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/index" class="text-black hover:underline">Cancel</a>
+            </div>
+        </form>
+    </div>
 </div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/document_templates/edit.php
+++ b/app/views/document_templates/edit.php
@@ -2,30 +2,32 @@
 require_once __DIR__ . '/../layouts/header.php';
 $template = $data['template'] ?? null;
 ?>
-<div class="container mx-auto p-4">
-    <h2 class="text-3xl font-bold text-neon-purple mb-6">Edit Document Template: <?php echo htmlspecialchars($template['name'] ?? 'N/A'); ?></h2>
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-2xl font-bold text-black mb-6">Edit Document Template: <?php echo htmlspecialchars($template['name'] ?? 'N/A'); ?></h2>
     <?php if ($template): ?>
-    <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/update/<?php echo $template['id']; ?>" method="POST" class="space-y-6 bg-brand-gray p-6 rounded-lg shadow-lg">
-        <div>
-            <label for="name" class="block text-sm font-medium text-gray-300 mb-1">Template Name:</label>
-            <input type="text" id="name" name="name" value="<?php echo htmlspecialchars(isset($_GET['name']) ? $_GET['name'] : $template['name']); ?>" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-        </div>
-        <div>
-            <label for="description" class="block text-sm font-medium text-gray-300 mb-1">Description:</label>
-            <textarea id="description" name="description" rows="3" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors"><?php echo htmlspecialchars(isset($_GET['description']) ? $_GET['description'] : $template['description']); ?></textarea>
-        </div>
-        <div>
-            <label for="fields_definition" class="block text-sm font-medium text-gray-300 mb-1">Fields Definition (JSON):</label>
-            <textarea id="fields_definition" name="fields_definition" rows="10" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded font-mono text-sm focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors"><?php echo htmlspecialchars(isset($_GET['fields_definition']) ? $_GET['fields_definition'] : $template['fields_definition']); ?></textarea>
-            <p class="text-xs text-gray-500 mt-1">Edit the JSON array defining the fields. Ensure valid JSON format.</p>
-        </div>
-        <div>
-            <button type="submit" class="bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-6 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-save mr-2"></i> Update Template</button>
-            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/index" class="ml-4 text-gray-400 hover:text-gray-200">Cancel</a>
-        </div>
-    </form>
+    <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+        <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/update/<?php echo $template['id']; ?>" method="POST" class="space-y-6">
+            <div>
+                <label for="name" class="block text-sm font-bold text-black mb-1">Template Name:</label>
+                <input type="text" id="name" name="name" value="<?php echo htmlspecialchars(isset($_GET['name']) ? $_GET['name'] : $template['name']); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+            </div>
+            <div>
+                <label for="description" class="block text-sm font-bold text-black mb-1">Description:</label>
+                <textarea id="description" name="description" rows="3" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black"><?php echo htmlspecialchars(isset($_GET['description']) ? $_GET['description'] : $template['description']); ?></textarea>
+            </div>
+            <div>
+                <label for="fields_definition" class="block text-sm font-bold text-black mb-1">Fields Definition (JSON):</label>
+                <textarea id="fields_definition" name="fields_definition" rows="10" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black font-mono text-sm"><?php echo htmlspecialchars(isset($_GET['fields_definition']) ? $_GET['fields_definition'] : $template['fields_definition']); ?></textarea>
+                <p class="text-xs text-gray-600 mt-1">Edit the JSON array defining the fields. Ensure valid JSON format.</p>
+            </div>
+            <div class="flex items-center justify-between">
+                <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-save mr-2"></i> Update Template</button>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/index" class="text-black hover:underline">Cancel</a>
+            </div>
+        </form>
+    </div>
     <?php else: ?>
-        <p class="text-red-500">Template data not found.</p>
+        <p class="text-red-600 text-center">Template data not found.</p>
     <?php endif; ?>
 </div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/document_templates/index.php
+++ b/app/views/document_templates/index.php
@@ -1,37 +1,37 @@
 <?php // app/views/document_templates/index.php
 require_once __DIR__ . '/../layouts/header.php'; ?>
-<div class="container mx-auto p-4">
+<div class="container mx-auto px-4 py-8">
     <div class="flex justify-between items-center mb-6">
-        <h2 class="text-3xl font-bold text-neon-purple">Document Templates</h2>
-        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/showCreateForm" class="bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors duration-300 ease-in-out transform hover:scale-105">
+        <h2 class="text-2xl font-bold text-black">Document Templates</h2>
+        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/showCreateForm" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline">
             <i class="fas fa-plus mr-2"></i> Create New Template
         </a>
     </div>
 
     <?php if (empty($data['templates'])): ?>
-        <p class="text-gray-400">No document templates found. Create one to get started!</p>
+        <p class="text-black">No document templates found. Create one to get started!</p>
     <?php else: ?>
-        <div class="overflow-x-auto bg-brand-gray shadow-md rounded-lg">
-            <table class="min-w-full divide-y divide-gray-700">
-                <thead class="bg-brand-dark">
+        <div class="overflow-x-auto">
+            <table class="min-w-full bg-white border border-black rounded-lg shadow-md">
+                <thead class="bg-black text-white">
                     <tr>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Name</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Description</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Created By</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Last Updated</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Actions</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Name</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Description</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Created By</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Last Updated</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
-                <tbody class="divide-y divide-gray-700">
+                <tbody class="bg-white divide-y divide-gray-200">
                     <?php foreach ($data['templates'] as $template): ?>
-                        <tr class="hover:bg-gray-700 transition-colors duration-150">
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-200"><?php echo htmlspecialchars($template['name']); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400"><?php echo htmlspecialchars(substr($template['description'] ?? '', 0, 50)) . (strlen($template['description'] ?? '') > 50 ? '...' : ''); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400"><?php echo htmlspecialchars($template['created_by_username'] ?? 'N/A'); ?></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400"><?php echo htmlspecialchars(date('M d, Y H:i', strtotime($template['updated_at']))); ?></td>
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold text-black"><?php echo htmlspecialchars($template['name']); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black"><?php echo htmlspecialchars(substr($template['description'] ?? '', 0, 50)) . (strlen($template['description'] ?? '') > 50 ? '...' : ''); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black"><?php echo htmlspecialchars($template['created_by_username'] ?? 'N/A'); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black"><?php echo htmlspecialchars(date('M d, Y H:i', strtotime($template['updated_at']))); ?></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
-                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/showEditForm/<?php echo $template['id']; ?>" class="text-blue-400 hover:text-blue-600"><i class="fas fa-pencil-alt mr-1"></i> Edit</a>
-                                <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/delete/<?php echo $template['id']; ?>" data-message="Are you sure you want to delete the template '<?php echo htmlspecialchars($template['name']); ?>'? This cannot be undone AND might fail if documents are using it." class="delete-confirm-link text-red-500 hover:text-red-700"><i class="fas fa-trash-alt mr-1"></i> Delete</a>
+                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/showEditForm/<?php echo $template['id']; ?>" class="text-black hover:underline"><i class="fas fa-pencil-alt mr-1"></i> Edit</a>
+                                <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>documenttemplate/delete/<?php echo $template['id']; ?>" data-message="Are you sure you want to delete the template '<?php echo htmlspecialchars($template['name']); ?>'? This cannot be undone AND might fail if documents are using it." class="delete-confirm-link text-red-600 hover:text-red-800 underline"><i class="fas fa-trash-alt mr-1"></i> Delete</a>
                             </td>
                         </tr>
                     <?php endforeach; ?>

--- a/app/views/documents/create.php
+++ b/app/views/documents/create.php
@@ -1,26 +1,35 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-
-<?php if (isset($data['process_id']) && isset($data['process_title'])): ?>
-    <h2 class="text-2xl font-semibold text-neon-purple mb-6">Add New Document to Process: <?php echo htmlspecialchars($data['process_title']); ?></h2>
-    <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/create/<?php echo $data['process_id']; ?>" method="POST" class="space-y-6 bg-brand-gray p-6 rounded-lg shadow-lg">
-        <div>
-            <label for="name" class="block text-gray-300 mb-1 font-semibold">Document Name:</label>
-            <input type="text" id="name" name="name" required value="<?php echo htmlspecialchars($_GET['name'] ?? ''); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
+<div class="container mx-auto px-4 py-8">
+    <?php if (isset($data['process_id']) && isset($data['process_title'])): ?>
+        <h2 class="text-2xl font-bold text-black mb-6">Add New Document to Process: <?php echo htmlspecialchars($data['process_title']); ?></h2>
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+            <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/create/<?php echo $data['process_id']; ?>" method="POST" class="space-y-6">
+                <div>
+                    <label for="name" class="block text-sm font-bold text-black mb-1">Document Name:</label>
+                    <input type="text" id="name" name="name" required value="<?php echo htmlspecialchars($_GET['name'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                </div>
+                <div>
+                    <label for="onedrive_url" class="block text-sm font-bold text-black mb-1">OneDrive URL:</label>
+                    <input type="url" id="onedrive_url" name="onedrive_url" placeholder="https://example.onedrive.com/..." value="<?php echo htmlspecialchars($_GET['onedrive_url'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                </div>
+                <div>
+                    <label for="status" class="block text-sm font-bold text-black mb-1">Status:</label>
+                    <select id="status" name="status" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                        <option value="pending" <?php echo (($_GET['status'] ?? 'pending') === 'pending') ? 'selected' : ''; ?>>Pending</option>
+                        <option value="submitted" <?php echo (($_GET['status'] ?? '') === 'submitted') ? 'selected' : ''; ?>>Submitted</option>
+                        <option value="approved" <?php echo (($_GET['status'] ?? '') === 'approved') ? 'selected' : ''; ?>>Approved</option>
+                        <option value="rejected" <?php echo (($_GET['status'] ?? '') === 'rejected') ? 'selected' : ''; ?>>Rejected</option>
+                    </select>
+                </div>
+                <div class="flex items-center justify-between">
+                    <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-plus mr-2"></i> Add Document</button>
+                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $data['process_id']; ?>" class="text-black hover:underline"><i class="fas fa-arrow-left mr-2"></i>Back to Process Details</a>
+                </div>
+            </form>
         </div>
-        <div>
-            <label for="onedrive_url" class="block text-gray-300 mb-1 font-semibold">OneDrive URL:</label>
-            <input type="url" id="onedrive_url" name="onedrive_url" placeholder="https://example.onedrive.com/..." value="<?php echo htmlspecialchars($_GET['onedrive_url'] ?? ''); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-        </div>
-        <div>
-            <label for="status" class="block text-gray-300 mb-1 font-semibold">Status:</label>
-            <input type="text" id="status" name="status" value="<?php echo htmlspecialchars($_GET['status'] ?? 'pending'); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-        </div>
-    <button type="submit" class="w-full md:w-auto bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-6 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-plus mr-2"></i> Add Document</button>
-    </form>
-<p class="mt-6"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $data['process_id']; ?>" class="text-neon-purple hover:text-purple-400"><i class="fas fa-arrow-left mr-2"></i>Back to Process Details</a></p>
-<?php else: ?>
-    <p class="text-red-400">Process information is missing. Cannot add document.</p>
-    <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index">Go to Accreditation Processes</a></p>
-<?php endif; ?>
-
+    <?php else: ?>
+        <p class="text-red-600 text-center">Process information is missing. Cannot add document.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Go to Accreditation Processes</a></p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/documents/edit_filled_form.php
+++ b/app/views/documents/edit_filled_form.php
@@ -5,68 +5,69 @@ $template = ['name' => $doc['template_name'] ?? 'N/A']; // Simplified template d
 $fields = $data['fields'] ?? [];
 $formData = $data['form_data'] ?? [];
 ?>
-<div class="container mx-auto p-4">
-    <h2 class="text-3xl font-bold text-neon-purple mb-2">Edit Document: <?php echo htmlspecialchars($doc['name'] ?? 'N/A'); ?></h2>
-    <p class="text-gray-400 mb-6">Template: <?php echo htmlspecialchars($template['name']); ?></p>
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-2xl font-bold text-black mb-2">Edit Document: <?php echo htmlspecialchars($doc['name'] ?? 'N/A'); ?></h2>
+    <p class="text-sm text-black mb-6">Template: <?php echo htmlspecialchars($template['name']); ?></p>
 
     <?php if ($doc && !empty($fields)): ?>
-    <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/update/<?php echo $doc['id']; ?>" method="POST" class="space-y-6 bg-brand-gray p-6 rounded-lg shadow-lg">
-        <div>
-            <label for="filled_document_title" class="block text-sm font-medium text-gray-300 mb-1">Document Title:</label>
-            <input type="text" id="filled_document_title" name="filled_document_title" value="<?php echo htmlspecialchars($doc['name']); ?>" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-        </div>
-
-        <?php foreach ($fields as $field):
-            $fieldName = htmlspecialchars($field['name'] ?? uniqid('field_'));
-            $fieldLabel = htmlspecialchars($field['label'] ?? ucfirst(str_replace('_', ' ', $fieldName)));
-            $fieldType = $field['type'] ?? 'text';
-            $fieldRequired = isset($field['required']) && $field['required'] ? 'required' : '';
-            $fieldPlaceholder = htmlspecialchars($field['placeholder'] ?? '');
-            $fieldValue = $formData[$field['name']] ?? '';
-        ?>
+    <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+        <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/update/<?php echo $doc['id']; ?>" method="POST" class="space-y-6">
             <div>
-                <label for="<?php echo $fieldName; ?>" class="block text-sm font-medium text-gray-300 mb-1"><?php echo $fieldLabel; ?><?php if($fieldRequired) echo '<span class="text-red-500">*</span>'; ?></label>
-                <?php if ($fieldType === 'textarea'): ?>
-                    <textarea id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" rows="5" placeholder="<?php echo $fieldPlaceholder; ?>" <?php echo $fieldRequired; ?> class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors"><?php echo htmlspecialchars($fieldValue); ?></textarea>
-                <?php elseif ($fieldType === 'select' && isset($field['options']) && is_array($field['options'])): ?>
-                    <select id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" <?php echo $fieldRequired; ?> class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-                        <option value="">Select an option</option>
-                        <?php foreach($field['options'] as $option_key => $option_val):
-                             $val = is_string($option_key) ? $option_key : $option_val;
-                             $label = $option_val;
-                        ?>
-                            <option value="<?php echo htmlspecialchars($val); ?>" <?php if ($fieldValue == $val) echo 'selected'; ?>><?php echo htmlspecialchars($label); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                <?php elseif ($fieldType === 'checkbox'): ?>
-                     <?php if (isset($field['options']) && is_array($field['options'])): // Multiple checkboxes ?>
-                        <div class="space-y-2 mt-1">
-                        <?php foreach($field['options'] as $option_key => $option_val):
-                            $val = is_string($option_key) ? $option_key : $option_val;
-                            $label = $option_val;
-                            $checkboxName = $fieldName . '[' . htmlspecialchars($val) . ']';
-                            $isChecked = isset($fieldValue[$val]);
-                        ?>
-                            <label class="flex items-center text-gray-300">
-                                <input type="checkbox" name="<?php echo $checkboxName; ?>" value="<?php echo htmlspecialchars($val); ?>" <?php if ($isChecked) echo 'checked'; ?> class="h-4 w-4 bg-brand-dark border-gray-600 text-neon-purple focus:ring-neon-purple rounded mr-2">
-                                <?php echo htmlspecialchars($label); ?>
-                            </label>
-                        <?php endforeach; ?>
-                        </div>
-                    <?php else: // Single checkbox ?>
-                        <label class="flex items-center text-gray-300">
-                            <input type="checkbox" id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" value="1" <?php if ($fieldValue == '1' || $fieldValue === true) echo 'checked'; ?> class="h-4 w-4 bg-brand-dark border-gray-600 text-neon-purple focus:ring-neon-purple rounded mr-2">
-                            <span class="ml-2"><?php echo $fieldPlaceholder ?: ($fieldLabel !== 'Yes' ? $fieldLabel : 'Yes'); ?></span>
-                        </label>
-                    <?php endif; ?>
-                <?php else: // text, date, number, email, etc. ?>
-                    <input type="<?php echo htmlspecialchars($fieldType); ?>" id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" value="<?php echo htmlspecialchars($fieldValue); ?>" placeholder="<?php echo $fieldPlaceholder; ?>" <?php echo $fieldRequired; ?> class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-                <?php endif; ?>
+                <label for="filled_document_title" class="block text-sm font-bold text-black mb-1">Document Title:</label>
+                <input type="text" id="filled_document_title" name="filled_document_title" value="<?php echo htmlspecialchars($doc['name']); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
             </div>
-        <?php endforeach; ?>
+
+            <?php foreach ($fields as $field):
+                $fieldName = htmlspecialchars($field['name'] ?? uniqid('field_'));
+                $fieldLabel = htmlspecialchars($field['label'] ?? ucfirst(str_replace('_', ' ', $fieldName)));
+                $fieldType = $field['type'] ?? 'text';
+                $fieldRequired = isset($field['required']) && $field['required'] ? 'required' : '';
+                $fieldPlaceholder = htmlspecialchars($field['placeholder'] ?? '');
+                $fieldValue = $formData[$field['name']] ?? '';
+            ?>
+                <div>
+                    <label for="<?php echo $fieldName; ?>" class="block text-sm font-bold text-black mb-1"><?php echo $fieldLabel; ?><?php if($fieldRequired) echo '<span class="text-red-500 ml-1">*</span>'; ?></label>
+                    <?php if ($fieldType === 'textarea'): ?>
+                        <textarea id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" rows="5" placeholder="<?php echo $fieldPlaceholder; ?>" <?php echo $fieldRequired; ?> class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black"><?php echo htmlspecialchars($fieldValue); ?></textarea>
+                    <?php elseif ($fieldType === 'select' && isset($field['options']) && is_array($field['options'])): ?>
+                        <select id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" <?php echo $fieldRequired; ?> class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                            <option value="">Select an option</option>
+                            <?php foreach($field['options'] as $option_key => $option_val):
+                                 $val = is_string($option_key) ? $option_key : $option_val;
+                                 $label = $option_val;
+                            ?>
+                                <option value="<?php echo htmlspecialchars($val); ?>" <?php if ($fieldValue == $val) echo 'selected'; ?>><?php echo htmlspecialchars($label); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    <?php elseif ($fieldType === 'checkbox'): ?>
+                         <?php if (isset($field['options']) && is_array($field['options'])): // Multiple checkboxes ?>
+                            <div class="space-y-2 mt-2">
+                            <?php foreach($field['options'] as $option_key => $option_val):
+                                $val = is_string($option_key) ? $option_key : $option_val;
+                                $label = $option_val;
+                                $checkboxName = $fieldName . '[' . htmlspecialchars($val) . ']';
+                                $isChecked = isset($fieldValue[$val]);
+                            ?>
+                                <label class="flex items-center text-sm text-black">
+                                    <input type="checkbox" name="<?php echo $checkboxName; ?>" value="<?php echo htmlspecialchars($val); ?>" <?php if ($isChecked) echo 'checked'; ?> class="h-4 w-4 bg-white border-black text-blue-600 focus:ring-blue-500 rounded mr-2">
+                                    <?php echo htmlspecialchars($label); ?>
+                                </label>
+                            <?php endforeach; ?>
+                            </div>
+                        <?php else: // Single checkbox ?>
+                            <label class="flex items-center text-sm text-black mt-2">
+                                <input type="checkbox" id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" value="1" <?php if ($fieldValue == '1' || $fieldValue === true) echo 'checked'; ?> class="h-4 w-4 bg-white border-black text-blue-600 focus:ring-blue-500 rounded mr-2">
+                                <span class="ml-2"><?php echo $fieldPlaceholder ?: ($fieldLabel !== 'Yes' ? $fieldLabel : 'Yes'); ?></span>
+                            </label>
+                        <?php endif; ?>
+                    <?php else: // text, date, number, email, etc. ?>
+                        <input type="<?php echo htmlspecialchars($fieldType); ?>" id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" value="<?php echo htmlspecialchars($fieldValue); ?>" placeholder="<?php echo $fieldPlaceholder; ?>" <?php echo $fieldRequired; ?> class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
             <div>
-                <label for="status" class="block text-sm font-medium text-gray-300 mb-1">Status:</label>
-                <select id="status" name="status" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
+                <label for="status" class="block text-sm font-bold text-black mb-1">Status:</label>
+                <select id="status" name="status" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
                     <option value="draft" <?php if ($doc['status'] === 'draft') echo 'selected'; ?>>Draft</option>
                     <option value="submitted" <?php if ($doc['status'] === 'submitted') echo 'selected'; ?>>Submitted</option>
                     <option value="completed" <?php if ($doc['status'] === 'completed') echo 'selected'; ?>>Completed</option>
@@ -74,14 +75,15 @@ $formData = $data['form_data'] ?? [];
                     <option value="rejected" <?php if ($doc['status'] === 'rejected') echo 'selected'; ?>>Rejected</option>
                 </select>
             </div>
-        <div>
-            <button type="submit" class="bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-6 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-save mr-2"></i> Update Document</button>
-            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/view/<?php echo $doc['id']; ?>" class="ml-4 text-gray-400 hover:text-gray-200">Cancel</a>
-        </div>
-    </form>
+            <div class="flex items-center justify-between">
+                <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-save mr-2"></i> Update Document</button>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/view/<?php echo $doc['id']; ?>" class="text-black hover:underline">Cancel</a>
+            </div>
+        </form>
+    </div>
     <?php else: ?>
-        <p class="text-red-500">Error: Document data not found or template definition invalid.</p>
-            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-neon-purple hover:text-purple-400">Go to Processes</a>
+        <p class="text-red-600 text-center">Error: Document data not found or template definition invalid.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Go to Processes</a></p>
     <?php endif; ?>
 </div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/documents/fill_form.php
+++ b/app/views/documents/fill_form.php
@@ -4,72 +4,74 @@ $template = $data['template'] ?? null;
 $process = $data['process'] ?? null;
 $fields = $data['fields'] ?? [];
 ?>
-<div class="container mx-auto p-4">
-    <h2 class="text-3xl font-bold text-neon-purple mb-2">Fill Document: <?php echo htmlspecialchars($template['name'] ?? 'N/A'); ?></h2>
-    <p class="text-gray-400 mb-6">For Process: <?php echo htmlspecialchars($process['title'] ?? 'N/A'); ?></p>
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-2xl font-bold text-black mb-2">Fill Document: <?php echo htmlspecialchars($template['name'] ?? 'N/A'); ?></h2>
+    <p class="text-sm text-black mb-6">For Process: <?php echo htmlspecialchars($process['title'] ?? 'N/A'); ?></p>
 
     <?php if ($template && $process && !empty($fields)): ?>
-    <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/save/<?php echo $process['id']; ?>/<?php echo $template['id']; ?>" method="POST" class="space-y-6 bg-brand-gray p-6 rounded-lg shadow-lg">
-        <div>
-            <label for="filled_document_title" class="block text-sm font-medium text-gray-300 mb-1">Document Title:</label>
-            <input type="text" id="filled_document_title" name="filled_document_title" value="<?php echo htmlspecialchars($template['name'] . ' - ' . date('Y-m-d')); ?>" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-        </div>
-
-        <?php foreach ($fields as $field):
-            $fieldName = htmlspecialchars($field['name'] ?? uniqid('field_'));
-            $fieldLabel = htmlspecialchars($field['label'] ?? ucfirst(str_replace('_', ' ', $fieldName)));
-            $fieldType = $field['type'] ?? 'text';
-            $fieldRequired = isset($field['required']) && $field['required'] ? 'required' : '';
-            $fieldPlaceholder = htmlspecialchars($field['placeholder'] ?? '');
-            $fieldValue = ''; // For create form, value is empty
-        ?>
+    <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+        <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/save/<?php echo $process['id']; ?>/<?php echo $template['id']; ?>" method="POST" class="space-y-6">
             <div>
-                <label for="<?php echo $fieldName; ?>" class="block text-sm font-medium text-gray-300 mb-1"><?php echo $fieldLabel; ?><?php if($fieldRequired) echo '<span class="text-red-500">*</span>'; ?></label>
-                <?php if ($fieldType === 'textarea'): ?>
-                    <textarea id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" rows="5" placeholder="<?php echo $fieldPlaceholder; ?>" <?php echo $fieldRequired; ?> class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors"><?php echo $fieldValue; ?></textarea>
-                <?php elseif ($fieldType === 'select' && isset($field['options']) && is_array($field['options'])): ?>
-                    <select id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" <?php echo $fieldRequired; ?> class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-                        <option value="">Select an option</option>
-                        <?php foreach($field['options'] as $option_key => $option_val):  // Allow for key => value or just value
-                             $val = is_string($option_key) ? $option_key : $option_val;
-                             $label = $option_val;
-                        ?>
-                            <option value="<?php echo htmlspecialchars($val); ?>" <?php if ($fieldValue == $val) echo 'selected'; ?>><?php echo htmlspecialchars($label); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                <?php elseif ($fieldType === 'checkbox'): ?>
-                    <?php if (isset($field['options']) && is_array($field['options'])): // Multiple checkboxes ?>
-                        <div class="space-y-2 mt-1">
-                        <?php foreach($field['options'] as $option_key => $option_val):
-                            $val = is_string($option_key) ? $option_key : $option_val;
-                            $label = $option_val;
-                            $checkboxName = $fieldName . '[' . htmlspecialchars($val) . ']'; // For array of checkboxes
-                        ?>
-                            <label class="flex items-center text-gray-300">
-                                <input type="checkbox" name="<?php echo $checkboxName; ?>" value="<?php echo htmlspecialchars($val); ?>" class="h-4 w-4 bg-brand-dark border-gray-600 text-neon-purple focus:ring-neon-purple rounded mr-2">
-                                <?php echo htmlspecialchars($label); ?>
-                            </label>
-                        <?php endforeach; ?>
-                        </div>
-                    <?php else: // Single checkbox ?>
-                         <label class="flex items-center text-gray-300">
-                            <input type="checkbox" id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" value="1" <?php if ($fieldValue == '1') echo 'checked'; ?> class="h-4 w-4 bg-brand-dark border-gray-600 text-neon-purple focus:ring-neon-purple rounded mr-2">
-                            <span class="ml-2"><?php echo $fieldPlaceholder ?: 'Yes'; ?></span>
-                        </label>
-                    <?php endif; ?>
-                <?php else: // text, date, number, email, etc. ?>
-                    <input type="<?php echo htmlspecialchars($fieldType); ?>" id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" value="<?php echo $fieldValue; ?>" placeholder="<?php echo $fieldPlaceholder; ?>" <?php echo $fieldRequired; ?> class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-                <?php endif; ?>
+                <label for="filled_document_title" class="block text-sm font-bold text-black mb-1">Document Title:</label>
+                <input type="text" id="filled_document_title" name="filled_document_title" value="<?php echo htmlspecialchars($template['name'] . ' - ' . date('Y-m-d')); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
             </div>
-        <?php endforeach; ?>
-        <div>
-            <button type="submit" class="bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-6 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-save mr-2"></i> Save Document</button>
-            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/selectTemplate/<?php echo $process['id']; ?>" class="ml-4 text-gray-400 hover:text-gray-200">Cancel / Change Template</a>
-        </div>
-    </form>
+
+            <?php foreach ($fields as $field):
+                $fieldName = htmlspecialchars($field['name'] ?? uniqid('field_'));
+                $fieldLabel = htmlspecialchars($field['label'] ?? ucfirst(str_replace('_', ' ', $fieldName)));
+                $fieldType = $field['type'] ?? 'text';
+                $fieldRequired = isset($field['required']) && $field['required'] ? 'required' : '';
+                $fieldPlaceholder = htmlspecialchars($field['placeholder'] ?? '');
+                $fieldValue = ''; // For create form, value is empty
+            ?>
+                <div>
+                    <label for="<?php echo $fieldName; ?>" class="block text-sm font-bold text-black mb-1"><?php echo $fieldLabel; ?><?php if($fieldRequired) echo '<span class="text-red-500 ml-1">*</span>'; ?></label>
+                    <?php if ($fieldType === 'textarea'): ?>
+                        <textarea id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" rows="5" placeholder="<?php echo $fieldPlaceholder; ?>" <?php echo $fieldRequired; ?> class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black"><?php echo $fieldValue; ?></textarea>
+                    <?php elseif ($fieldType === 'select' && isset($field['options']) && is_array($field['options'])): ?>
+                        <select id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" <?php echo $fieldRequired; ?> class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                            <option value="">Select an option</option>
+                            <?php foreach($field['options'] as $option_key => $option_val):
+                                 $val = is_string($option_key) ? $option_key : $option_val;
+                                 $label = $option_val;
+                            ?>
+                                <option value="<?php echo htmlspecialchars($val); ?>" <?php if ($fieldValue == $val) echo 'selected'; ?>><?php echo htmlspecialchars($label); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    <?php elseif ($fieldType === 'checkbox'): ?>
+                        <?php if (isset($field['options']) && is_array($field['options'])): // Multiple checkboxes ?>
+                            <div class="space-y-2 mt-2">
+                            <?php foreach($field['options'] as $option_key => $option_val):
+                                $val = is_string($option_key) ? $option_key : $option_val;
+                                $label = $option_val;
+                                $checkboxName = $fieldName . '[' . htmlspecialchars($val) . ']';
+                            ?>
+                                <label class="flex items-center text-sm text-black">
+                                    <input type="checkbox" name="<?php echo $checkboxName; ?>" value="<?php echo htmlspecialchars($val); ?>" class="h-4 w-4 bg-white border-black text-blue-600 focus:ring-blue-500 rounded mr-2">
+                                    <?php echo htmlspecialchars($label); ?>
+                                </label>
+                            <?php endforeach; ?>
+                            </div>
+                        <?php else: // Single checkbox ?>
+                             <label class="flex items-center text-sm text-black mt-2">
+                                <input type="checkbox" id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" value="1" <?php if ($fieldValue == '1') echo 'checked'; ?> class="h-4 w-4 bg-white border-black text-blue-600 focus:ring-blue-500 rounded mr-2">
+                                <span class="ml-2"><?php echo $fieldPlaceholder ?: ($fieldLabel !== 'Yes' ? $fieldLabel : 'Yes'); ?></span>
+                            </label>
+                        <?php endif; ?>
+                    <?php else: // text, date, number, email, etc. ?>
+                        <input type="<?php echo htmlspecialchars($fieldType); ?>" id="<?php echo $fieldName; ?>" name="<?php echo $fieldName; ?>" value="<?php echo $fieldValue; ?>" placeholder="<?php echo $fieldPlaceholder; ?>" <?php echo $fieldRequired; ?> class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
+            <div class="flex items-center justify-between">
+                <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-save mr-2"></i> Save Document</button>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/selectTemplate/<?php echo $process['id']; ?>" class="text-black hover:underline">Cancel / Change Template</a>
+            </div>
+        </form>
+    </div>
     <?php else: ?>
-        <p class="text-red-500">Error: Template or process information is missing, or template definition is invalid.</p>
-        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-neon-purple hover:text-purple-400">Go to Processes</a>
+        <p class="text-red-600 text-center">Error: Template or process information is missing, or template definition is invalid.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Go to Processes</a></p>
     <?php endif; ?>
 </div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/documents/select_template.php
+++ b/app/views/documents/select_template.php
@@ -2,17 +2,19 @@
 require_once __DIR__ . '/../layouts/header.php';
 $process = $data['process'] ?? null;
 ?>
-<div class="container mx-auto p-4">
-    <h2 class="text-3xl font-bold text-neon-purple mb-6">Select a Template for Process: <?php echo htmlspecialchars($process['title'] ?? 'N/A'); ?></h2>
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-2xl font-bold text-black mb-6">Select a Template for Process: <?php echo htmlspecialchars($process['title'] ?? 'N/A'); ?></h2>
     <?php if (empty($data['templates'])): ?>
-        <p class="text-gray-400">No document templates available. A superuser needs to create them first.</p>
+        <p class="text-black">No document templates available. A superuser needs to create them first.</p>
     <?php else: ?>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <?php foreach ($data['templates'] as $template): ?>
-                <div class="bg-brand-gray p-6 rounded-lg shadow-lg hover:shadow-neon-purple/30 transition-shadow duration-300">
-                    <h3 class="text-xl font-semibold text-neon-purple mb-2"><?php echo htmlspecialchars($template['name']); ?></h3>
-                    <p class="text-gray-400 mb-4 text-sm"><?php echo htmlspecialchars($template['description'] ?? 'No description.'); ?></p>
-                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/fill/<?php echo $process['id']; ?>/<?php echo $template['id']; ?>" class="bg-blue-500 text-white hover:bg-blue-700 font-bold py-2 px-4 rounded transition-colors duration-300 ease-in-out transform hover:scale-105">
+                <div class="bg-white border border-black p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 flex flex-col justify-between">
+                    <div>
+                        <h3 class="text-xl font-semibold text-black mb-2"><?php echo htmlspecialchars($template['name']); ?></h3>
+                        <p class="text-black text-sm mb-4"><?php echo htmlspecialchars($template['description'] ?? 'No description.'); ?></p>
+                    </div>
+                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/fill/<?php echo $process['id']; ?>/<?php echo $template['id']; ?>" class="self-start bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline">
                         <i class="fas fa-file-alt mr-2"></i> Use this template
                     </a>
                 </div>
@@ -20,7 +22,7 @@ $process = $data['process'] ?? null;
         </div>
     <?php endif; ?>
     <div class="mt-8">
-      <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $process['id']; ?>" class="text-gray-400 hover:text-gray-200"><i class="fas fa-arrow-left mr-2"></i> Back to Process</a>
+      <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $process['id']; ?>" class="text-black hover:underline"><i class="fas fa-arrow-left mr-2"></i> Back to Process</a>
     </div>
 </div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/documents/view_filled_document.php
+++ b/app/views/documents/view_filled_document.php
@@ -4,37 +4,37 @@ $doc = $data['filledDocument'] ?? null;
 $fields = $data['fields'] ?? [];
 $formData = $data['form_data'] ?? [];
 ?>
-<div class="container mx-auto p-4">
+<div class="container mx-auto px-4 py-8">
     <?php if ($doc && !empty($fields)): ?>
-        <div class="bg-brand-gray p-6 rounded-lg shadow-lg">
-            <div class="flex justify-between items-start mb-4">
-              <div>
-                  <h2 class="text-3xl font-bold text-neon-purple mb-1"><?php echo htmlspecialchars($doc['name']); ?></h2>
-                  <p class="text-sm text-gray-500">Template: <?php echo htmlspecialchars($doc['template_name']); ?></p>
-                  <p class="text-sm text-gray-500">Status: <span class="font-semibold <?php
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+            <div class="flex flex-col sm:flex-row justify-between items-start mb-4">
+              <div class="mb-4 sm:mb-0">
+                  <h2 class="text-2xl font-bold text-black mb-1"><?php echo htmlspecialchars($doc['name']); ?></h2>
+                  <p class="text-sm text-gray-600">Template: <?php echo htmlspecialchars($doc['template_name']); ?></p>
+                  <p class="text-sm text-gray-600">Status: <span class="font-semibold px-1 rounded-full text-xs <?php
                         switch (strtolower($doc['status'] ?? '')) {
-                            case 'submitted': echo 'text-blue-400'; break;
-                            case 'draft': echo 'text-yellow-400'; break;
-                            case 'completed': echo 'text-green-400'; break;
-                            case 'approved': echo 'text-green-400'; break;
-                            case 'rejected': echo 'text-red-400'; break;
-                            default: echo 'text-gray-400';
+                            case 'submitted': echo 'bg-blue-100 text-blue-800 border border-blue-400'; break;
+                            case 'draft': echo 'bg-yellow-100 text-yellow-800 border border-yellow-400'; break;
+                            case 'completed': echo 'bg-green-100 text-green-800 border border-green-400'; break; // Assuming completed is like approved
+                            case 'approved': echo 'bg-green-100 text-green-800 border border-green-400'; break;
+                            case 'rejected': echo 'bg-red-100 text-red-800 border border-red-400'; break;
+                            default: echo 'bg-gray-100 text-gray-800 border border-gray-400';
                         }
                     ?>"><?php echo ucfirst(htmlspecialchars($doc['status'])); ?></span></p>
-                  <p class="text-sm text-gray-500">Created by: <?php echo htmlspecialchars($doc['created_by_username']); ?> on <?php echo htmlspecialchars(date('M d, Y H:i', strtotime($doc['created_at'])));?></p>
-                  <p class="text-sm text-gray-500">Last updated: <?php echo htmlspecialchars(date('M d, Y H:i', strtotime($doc['updated_at'])));?></p>
+                  <p class="text-sm text-gray-600">Created by: <?php echo htmlspecialchars($doc['created_by_username']); ?> on <?php echo htmlspecialchars(date('M d, Y H:i', strtotime($doc['created_at'])));?></p>
+                  <p class="text-sm text-gray-600">Last updated: <?php echo htmlspecialchars(date('M d, Y H:i', strtotime($doc['updated_at'])));?></p>
               </div>
-              <div class="space-x-2 whitespace-nowrap">
+              <div class="flex space-x-2 whitespace-nowrap">
                   <?php if($doc['user_id'] == ($_SESSION['user_id'] ?? null) || (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser')): ?>
-                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/edit/<?php echo $doc['id']; ?>" class="bg-blue-500 text-white hover:bg-blue-700 font-semibold py-2 px-4 rounded transition-colors text-sm"><i class="fas fa-pencil-alt mr-1"></i> Edit</a>
+                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/edit/<?php echo $doc['id']; ?>" class="bg-black text-white px-3 py-2 rounded hover:bg-gray-800 text-sm"><i class="fas fa-pencil-alt mr-1"></i> Edit</a>
                   <?php endif; ?>
-                  <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $doc['id']; ?>" class="bg-green-500 text-white hover:bg-green-700 font-semibold py-2 px-4 rounded transition-colors text-sm"><i class="fas fa-tasks mr-1"></i> View Tasks</a>
-                  <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/exportAsJson/<?php echo $doc['id']; ?>" target="_blank" class="bg-gray-600 text-white hover:bg-gray-700 font-semibold py-2 px-4 rounded transition-colors text-sm inline-flex items-center">
-                      <i class="fas fa-file-export mr-2"></i> Export as JSON
+                  <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $doc['id']; ?>" class="bg-black text-white px-3 py-2 rounded hover:bg-gray-800 text-sm"><i class="fas fa-tasks mr-1"></i> View Tasks</a>
+                  <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>document/exportAsJson/<?php echo $doc['id']; ?>" target="_blank" class="bg-gray-600 text-white px-3 py-2 rounded hover:bg-gray-700 text-sm inline-flex items-center">
+                      <i class="fas fa-file-export mr-2"></i> Export JSON
                   </a>
               </div>
             </div>
-            <hr class="border-gray-700 my-6">
+            <hr class="border-black my-6">
             <div class="space-y-6">
                 <?php foreach ($fields as $field):
                     $fieldName = $field['name'] ?? uniqid('field_');
@@ -43,8 +43,8 @@ $formData = $data['form_data'] ?? [];
                     $fieldType = $field['type'] ?? 'text';
                 ?>
                     <div>
-                        <h4 class="block text-sm font-semibold text-gray-400 mb-1"><?php echo $fieldLabel; ?>:</h4>
-                        <div class="p-3 bg-brand-dark rounded text-gray-200 min-h-[40px] prose prose-invert max-w-none"> <!-- prose-invert for markdown if used -->
+                        <p class="block text-sm font-semibold text-black mb-1"><?php echo $fieldLabel; ?>:</p>
+                        <div class="mt-1 block w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-md text-sm min-h-[40px] text-black">
                             <?php if ($fieldType === 'textarea'): ?>
                                 <?php echo nl2br(htmlspecialchars($fieldValue ?? 'N/A')); ?>
                             <?php elseif ($fieldType === 'checkbox'): ?>
@@ -75,12 +75,12 @@ $formData = $data['form_data'] ?? [];
                 <?php endforeach; ?>
             </div>
              <div class="mt-8">
-                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $doc['accreditation_process_id']; ?>" class="text-neon-purple hover:text-purple-400"><i class="fas fa-arrow-left mr-2"></i> Back to Process Documents</a>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $doc['accreditation_process_id']; ?>" class="text-black hover:underline"><i class="fas fa-arrow-left mr-2"></i> Back to Process Documents</a>
             </div>
         </div>
     <?php else: ?>
-        <p class="text-red-400">Error: Filled document data or template definition not found or invalid.</p>
-        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-neon-purple hover:text-purple-400">Go to Processes</a>
+        <p class="text-red-600 text-center">Error: Filled document data or template definition not found or invalid.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Go to Processes</a></p>
     <?php endif; ?>
 </div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -1,44 +1,46 @@
 <?php require_once __DIR__ . '/layouts/header.php'; // Adjusted path if home.php is in views/ directly ?>
-<h2 class="text-3xl font-bold text-neon-purple mb-4">Accreditation Dashboard</h2>
-<p class="text-lg text-gray-400 mb-6">Welcome, <?php echo htmlspecialchars($_SESSION['user_name'] ?? 'Guest'); ?>!</p>
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-3xl font-bold text-black mb-6">Accreditation Dashboard</h2>
+    <p class="text-lg text-black mb-6">Welcome, <?php echo htmlspecialchars($_SESSION['user_name'] ?? 'Guest'); ?>!</p>
 
-<h3 class="text-2xl font-semibold text-gray-200 mb-4">Accreditation Processes</h3>
-<?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
-    <p class="mb-4"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/showCreateForm" class="inline-block bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors duration-300"><i class="fas fa-plus mr-2"></i> Create New Process</a></p>
-<?php endif; ?>
+    <h3 class="text-2xl font-semibold text-black mb-4">Accreditation Processes</h3>
+    <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
+        <p class="mb-4"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/showCreateForm" class="inline-block bg-black text-white hover:bg-gray-800 font-bold py-2 px-4 rounded"><i class="fas fa-plus mr-2"></i> Create New Process</a></p>
+    <?php endif; ?>
 
-<?php if (isset($data['processes']) && !empty($data['processes'])): ?>
-    <ul class="space-y-4">
-        <?php foreach ($data['processes'] as $process): ?>
-            <li class="bg-brand-gray p-4 rounded-lg shadow hover:shadow-neon-purple/30 transition-shadow duration-300">
-                <div class="flex justify-between items-center">
-                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $process['id']; ?>" class="text-xl font-semibold text-neon-purple hover:text-purple-400">
-                        <?php echo htmlspecialchars($process['title']); ?>
-                    </a>
-                    <span class="text-sm font-medium px-3 py-1 rounded-full
-                        <?php
-                            switch (strtolower($process['status'] ?? '')) {
-                                case 'active': echo 'bg-green-600 text-green-100'; break;
-                                case 'pending': echo 'bg-yellow-600 text-yellow-100'; break;
-                                case 'completed': echo 'bg-blue-600 text-blue-100'; break;
-                                case 'archived': echo 'bg-gray-600 text-gray-100'; break;
-                                default: echo 'bg-gray-500 text-gray-100';
-                            }
-                        ?>">
-                        <?php echo htmlspecialchars(ucfirst($process['status'])); ?>
-                    </span>
-                </div>
-                <p class="text-gray-400 text-sm mt-1">Created by: <?php echo htmlspecialchars($process['created_by_name'] ?? 'N/A'); ?></p>
-                <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
-                    <div class="mt-3 text-right">
-                        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/showEditForm/<?php echo $process['id']; ?>" class="text-yellow-400 hover:text-yellow-600 mr-3"><i class="fas fa-pencil-alt mr-1"></i> Edit</a>
-                        <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/delete/<?php echo $process['id']; ?>" data-message="Are you sure you want to delete this process and ALL related data (documents, tasks, comments)? This action cannot be undone." class="delete-confirm-link text-red-400 hover:text-red-600"><i class="fas fa-trash-alt mr-1"></i> Delete</a>
+    <?php if (isset($data['processes']) && !empty($data['processes'])): ?>
+        <ul class="space-y-4">
+            <?php foreach ($data['processes'] as $process): ?>
+                <li class="bg-white border border-black p-4 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300">
+                    <div class="flex justify-between items-center">
+                        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $process['id']; ?>" class="text-xl font-semibold text-black hover:underline">
+                            <?php echo htmlspecialchars($process['title']); ?>
+                        </a>
+                        <span class="text-sm font-medium px-3 py-1 rounded-full
+                            <?php
+                                switch (strtolower($process['status'] ?? '')) {
+                                    case 'active': echo 'bg-green-600 text-green-100'; break;
+                                    case 'pending': echo 'bg-yellow-600 text-yellow-100'; break;
+                                    case 'completed': echo 'bg-blue-600 text-blue-100'; break;
+                                    case 'archived': echo 'bg-gray-600 text-gray-100'; break;
+                                    default: echo 'bg-gray-500 text-gray-100';
+                                }
+                            ?>">
+                            <?php echo htmlspecialchars(ucfirst($process['status'])); ?>
+                        </span>
                     </div>
-                <?php endif; ?>
-            </li>
-        <?php endforeach; ?>
-    </ul>
-<?php else: ?>
-    <p>No accreditation processes found.</p>
-<?php endif; ?>
+                    <p class="text-black text-sm mt-1">Created by: <?php echo htmlspecialchars($process['created_by_name'] ?? 'N/A'); ?></p>
+                    <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
+                        <div class="mt-3 text-right">
+                            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/showEditForm/<?php echo $process['id']; ?>" class="text-black hover:underline mr-3"><i class="fas fa-pencil-alt mr-1"></i> Edit</a>
+                            <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/delete/<?php echo $process['id']; ?>" data-message="Are you sure you want to delete this process and ALL related data (documents, tasks, comments)? This action cannot be undone." class="delete-confirm-link text-red-600 hover:text-red-800 hover:underline"><i class="fas fa-trash-alt mr-1"></i> Delete</a>
+                        </div>
+                    <?php endif; ?>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php else: ?>
+        <p class="text-black">No accreditation processes found.</p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/layouts/footer.php'; // Adjusted path ?>

--- a/app/views/layouts/footer.php
+++ b/app/views/layouts/footer.php
@@ -1,5 +1,5 @@
 </main> <!-- closes .container -->
-<footer class="bg-brand-dark text-gray-400 text-center p-4 mt-8">
+<footer class="bg-white border-t border-black text-black text-center py-4 mt-auto">
     <p>&copy; <?php echo date("Y"); ?> Ashesi University - AMS</p>
 </footer>
 <script>

--- a/app/views/layouts/header.php
+++ b/app/views/layouts/header.php
@@ -8,28 +8,28 @@
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
-<body class="bg-brand-dark text-gray-300"> <!-- Applied to body for full page effect -->
-<header class="bg-brand-dark text-gray-200 p-4 shadow-lg">
+<body> <!-- Ensure body class is controlled by input.css -->
+<header class="bg-white border-b border-black shadow-sm p-4">
     <div class="container mx-auto flex justify-between items-center">
         <h1 class="text-2xl font-bold">
-            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>home/index" class="text-neon-purple hover:text-purple-400 transition-colors">
+            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>home/index" class="text-black">
                 Accreditation Management System
             </a>
         </h1>
         <nav>
             <?php if (isset($_SESSION['user_id'])): ?>
-                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/profile" class="px-3 py-2 hover:bg-brand-gray rounded transition-colors">Profile</a>
-                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="px-3 py-2 hover:bg-brand-gray rounded transition-colors">Processes</a>
-                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/myTasks" class="px-3 py-2 hover:bg-brand-gray rounded transition-colors">My Tasks</a>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/profile" class="text-black hover:underline px-3 py-2 rounded-md text-sm font-medium">Profile</a>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline px-3 py-2 rounded-md text-sm font-medium">Processes</a>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/myTasks" class="text-black hover:underline px-3 py-2 rounded-md text-sm font-medium">My Tasks</a>
                 <?php if (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
-                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/listUsers" class="px-3 py-2 hover:bg-brand-gray rounded transition-colors">Users</a>
+                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/listUsers" class="text-black hover:underline px-3 py-2 rounded-md text-sm font-medium">Users</a>
                 <?php endif; ?>
-                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/logout" class="px-3 py-2 bg-neon-purple text-white hover:bg-purple-700 rounded transition-colors"><i class="fas fa-sign-out-alt mr-1"></i> Logout</a>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/logout" class="text-black hover:underline px-3 py-2 rounded-md text-sm font-medium"><i class="fas fa-sign-out-alt mr-1"></i> Logout</a>
             <?php else: ?>
-                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showLoginForm" class="px-3 py-2 hover:bg-brand-gray rounded transition-colors">Login</a>
-                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showRegistrationForm" class="px-3 py-2 hover:bg-brand-gray rounded transition-colors">Register</a>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showLoginForm" class="text-black hover:underline px-3 py-2 rounded-md text-sm font-medium">Login</a>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showRegistrationForm" class="text-black hover:underline px-3 py-2 rounded-md text-sm font-medium">Register</a>
             <?php endif; ?>
         </nav>
     </div>
 </header>
-<main class="container mx-auto p-4 bg-brand-gray min-h-screen">
+<main class="container mx-auto p-4 min-h-screen">

--- a/app/views/tasks/assign.php
+++ b/app/views/tasks/assign.php
@@ -1,26 +1,31 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-
-<?php if (isset($data['task']) && isset($data['allUsers']) && isset($data['assignedUserIds'])): ?>
-    <h2 class="text-2xl font-semibold text-neon-purple mb-4">Assign Task: "<?php echo htmlspecialchars($data['task']['description']); ?>"</h2>
-    <p class="text-gray-400 mb-6"><strong>For Document:</strong> <?php echo htmlspecialchars($data['task']['document_name']); ?></p>
-    <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/assign/<?php echo $data['task']['id']; ?>" method="POST" class="space-y-6 bg-brand-gray p-6 rounded-lg shadow-lg">
-        <div>
-            <label for="select-users-assign" class="block text-gray-300 mb-1 font-semibold">Select Users:</label>
-            <select id="select-users-assign" name="user_ids[]" multiple style="width: 100%;" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-                <?php foreach ($data['allUsers'] as $user): ?>
-                    <option value="<?php echo $user['id']; ?>" <?php echo in_array($user['id'], $data['assignedUserIds']) ? 'selected' : ''; ?>>
-                        <?php echo htmlspecialchars($user['name']) . " (" . htmlspecialchars($user['email']) . ")"; ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-            <p class="text-sm text-gray-500 mt-1">Hold Ctrl/Cmd to select multiple users. Select2 will enhance this.</p>
+<div class="container mx-auto px-4 py-8">
+    <?php if (isset($data['task']) && isset($data['allUsers']) && isset($data['assignedUserIds'])): ?>
+        <h2 class="text-2xl font-bold text-black mb-2">Assign Task: "<?php echo htmlspecialchars(substr($data['task']['description'], 0, 50)) . (strlen($data['task']['description']) > 50 ? '...' : ''); ?>"</h2>
+        <p class="text-sm text-black mb-6"><strong>For Document:</strong> <?php echo htmlspecialchars($data['task']['document_name']); ?></p>
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+            <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/assign/<?php echo $data['task']['id']; ?>" method="POST" class="space-y-6">
+                <div>
+                    <label for="select-users-assign" class="block text-sm font-bold text-black mb-1">Select Users:</label>
+                    <select id="select-users-assign" name="user_ids[]" multiple style="width: 100%;" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                        <?php foreach ($data['allUsers'] as $user): ?>
+                            <option value="<?php echo $user['id']; ?>" <?php echo in_array($user['id'], $data['assignedUserIds']) ? 'selected' : ''; ?>>
+                                <?php echo htmlspecialchars($user['name']) . " (" . htmlspecialchars($user['email']) . ")"; ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                    <p class="text-xs text-gray-600 mt-1">Hold Ctrl/Cmd to select multiple users. This field can be enhanced with a JavaScript library like Select2.</p>
+                </div>
+                <input type="hidden" name="document_id" value="<?php echo $data['task']['document_id']; ?>">
+                <div class="flex items-center justify-between">
+                    <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-users-cog mr-2"></i> Assign/Update Users</button>
+                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $data['task']['document_id']; ?>" class="text-black hover:underline"><i class="fas fa-arrow-left mr-2"></i>Back to Tasks for Document</a>
+                </div>
+            </form>
         </div>
-        <input type="hidden" name="document_id" value="<?php echo $data['task']['document_id']; ?>">
-        <button type="submit" class="w-full md:w-auto bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-6 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-users-cog mr-2"></i> Assign/Update Users</button>
-    </form>
-    <p class="mt-6"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $data['task']['document_id']; ?>" class="text-neon-purple hover:text-purple-400"><i class="fas fa-arrow-left mr-2"></i>Back to Tasks for Document</a></p>
-<?php else: ?>
-    <p class="text-red-400">Task details or user list not found. Cannot display assignment form.</p>
-    <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>index.php?url=accreditation/index">Go to Accreditation Processes</a></p>
-<?php endif; ?>
+    <?php else: ?>
+        <p class="text-red-600 text-center">Task details or user list not found. Cannot display assignment form.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Go to Accreditation Processes</a></p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/tasks/create.php
+++ b/app/views/tasks/create.php
@@ -1,31 +1,35 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-
-<?php if (isset($data['document_id']) && isset($data['document_name'])): ?>
-    <h2>Create New Task for Document: <?php echo htmlspecialchars($data['document_name']); ?></h2>
-    <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/create/<?php echo $data['document_id']; ?>" method="POST">
-        <div>
-            <label for="description">Description:</label>
-            <textarea id="description" name="description" required><?php echo htmlspecialchars($_GET['description'] ?? ''); ?></textarea>
+<div class="container mx-auto px-4 py-8">
+    <?php if (isset($data['document_id']) && isset($data['document_name'])): ?>
+        <h2 class="text-2xl font-bold text-black mb-6">Create New Task for Document: <?php echo htmlspecialchars($data['document_name']); ?></h2>
+        <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+            <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/create/<?php echo $data['document_id']; ?>" method="POST" class="space-y-6">
+                <div>
+                    <label for="description" class="block text-sm font-bold text-black mb-1">Description:</label>
+                    <textarea id="description" name="description" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" rows="4"><?php echo htmlspecialchars($_GET['description'] ?? ''); ?></textarea>
+                </div>
+                <div>
+                    <label for="due_date" class="block text-sm font-bold text-black mb-1">Due Date:</label>
+                    <input type="date" id="due_date" name="due_date" value="<?php echo htmlspecialchars($_GET['due_date'] ?? ''); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                </div>
+                <div>
+                    <label for="status" class="block text-sm font-bold text-black mb-1">Status:</label>
+                    <select id="status" name="status" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                        <option value="pending" <?php echo ((isset($_GET['status']) && $_GET['status'] === 'pending') || !isset($_GET['status'])) ? 'selected' : ''; ?>>Pending</option>
+                        <option value="in_progress" <?php echo (isset($_GET['status']) && $_GET['status'] === 'in_progress') ? 'selected' : ''; ?>>In Progress</option>
+                        <option value="completed" <?php echo (isset($_GET['status']) && $_GET['status'] === 'completed') ? 'selected' : ''; ?>>Completed</option>
+                        <option value="overdue" <?php echo (isset($_GET['status']) && $_GET['status'] === 'overdue') ? 'selected' : ''; ?>>Overdue</option>
+                    </select>
+                </div>
+                <div class="flex items-center justify-between">
+                    <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-plus mr-2"></i> Create Task</button>
+                    <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $data['document_id']; ?>" class="text-black hover:underline"><i class="fas fa-arrow-left mr-2"></i>Back to Tasks for Document</a>
+                </div>
+            </form>
         </div>
-        <div>
-            <label for="due_date">Due Date:</label>
-            <input type="date" id="due_date" name="due_date" value="<?php echo htmlspecialchars($_GET['due_date'] ?? ''); ?>">
-        </div>
-        <div>
-            <label for="status">Status:</label>
-            <select id="status" name="status">
-                <option value="pending" <?php echo (isset($_GET['status']) && $_GET['status'] === 'pending') ? 'selected' : ''; ?>>Pending</option>
-                <option value="in_progress" <?php echo (isset($_GET['status']) && $_GET['status'] === 'in_progress') ? 'selected' : ''; ?>>In Progress</option>
-                <option value="completed" <?php echo (isset($_GET['status']) && $_GET['status'] === 'completed') ? 'selected' : ''; ?>>Completed</option>
-                <option value="overdue" <?php echo (isset($_GET['status']) && $_GET['status'] === 'overdue') ? 'selected' : ''; ?>>Overdue</option>
-            </select>
-        </div>
-        <button type="submit" class="bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors"><i class="fas fa-plus mr-2"></i> Create Task</button>
-    </form>
-    <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $data['document_id']; ?>" class="text-blue-400 hover:text-blue-600 mt-4 inline-block"><i class="fas fa-arrow-left mr-2"></i>Back to Tasks for Document</a></p>
-<?php else: ?>
-    <p>Document information is missing. Cannot create task.</p>
-     <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>index.php?url=accreditation/index">Go to Accreditation Processes</a></p>
-<?php endif; ?>
-
+    <?php else: ?>
+        <p class="text-red-600 text-center">Document information is missing. Cannot create task.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Go to Accreditation Processes</a></p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/tasks/edit.php
+++ b/app/views/tasks/edit.php
@@ -1,30 +1,36 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2 class="text-2xl font-semibold text-neon-purple mb-6">Edit Task</h2>
-<?php if (isset($data['task'])): ?>
-<form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/update/<?php echo $data['task']['id']; ?>" method="POST" class="space-y-6 bg-brand-gray p-6 rounded-lg shadow-lg">
-    <div>
-        <label for="description" class="block text-gray-300 mb-1 font-semibold">Description:</label>
-        <textarea id="description" name="description" required class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors" rows="4"><?php echo htmlspecialchars($data['task']['description']); ?></textarea>
+<div class="container mx-auto px-4 py-8">
+    <?php if (isset($data['task'])): ?>
+    <h2 class="text-2xl font-bold text-black mb-6">Edit Task: <?php echo htmlspecialchars(substr($data['task']['description'], 0, 50)) . (strlen($data['task']['description']) > 50 ? '...' : ''); ?></h2>
+    <div class="bg-white p-6 rounded-lg shadow-md border border-black">
+        <form action="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/update/<?php echo $data['task']['id']; ?>" method="POST" class="space-y-6">
+            <div>
+                <label for="description" class="block text-sm font-bold text-black mb-1">Description:</label>
+                <textarea id="description" name="description" required class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black" rows="4"><?php echo htmlspecialchars($data['task']['description']); ?></textarea>
+            </div>
+            <div>
+                <label for="due_date" class="block text-sm font-bold text-black mb-1">Due Date:</label>
+                <input type="date" id="due_date" name="due_date" value="<?php echo htmlspecialchars($data['task']['due_date']); ?>" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+            </div>
+            <div>
+                <label for="status" class="block text-sm font-bold text-black mb-1">Status:</label>
+                <select id="status" name="status" class="mt-1 block w-full px-3 py-2 bg-white border border-black rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 text-black">
+                    <option value="pending" <?php echo ($data['task']['status'] === 'pending') ? 'selected' : ''; ?>>Pending</option>
+                    <option value="in_progress" <?php echo ($data['task']['status'] === 'in_progress') ? 'selected' : ''; ?>>In Progress</option>
+                    <option value="completed" <?php echo ($data['task']['status'] === 'completed') ? 'selected' : ''; ?>>Completed</option>
+                    <option value="overdue" <?php echo ($data['task']['status'] === 'overdue') ? 'selected' : ''; ?>>Overdue</option>
+                </select>
+            </div>
+            <input type="hidden" name="document_id" value="<?php echo $data['task']['document_id']; ?>">
+            <div class="flex items-center justify-between">
+                <button type="submit" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-save mr-2"></i> Update Task</button>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $data['task']['document_id']; ?>" class="text-black hover:underline"><i class="fas fa-arrow-left mr-2"></i>Back to Tasks for Document</a>
+            </div>
+        </form>
     </div>
-    <div>
-        <label for="due_date" class="block text-gray-300 mb-1 font-semibold">Due Date:</label>
-        <input type="date" id="due_date" name="due_date" value="<?php echo htmlspecialchars($data['task']['due_date']); ?>" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-    </div>
-    <div>
-        <label for="status" class="block text-gray-300 mb-1 font-semibold">Status:</label>
-        <select id="status" name="status" class="w-full p-3 bg-brand-dark border border-gray-600 text-gray-200 rounded focus:border-neon-purple focus:ring-1 focus:ring-neon-purple outline-none transition-colors">
-            <option value="pending" <?php echo ($data['task']['status'] === 'pending') ? 'selected' : ''; ?>>Pending</option>
-            <option value="in_progress" <?php echo ($data['task']['status'] === 'in_progress') ? 'selected' : ''; ?>>In Progress</option>
-            <option value="completed" <?php echo ($data['task']['status'] === 'completed') ? 'selected' : ''; ?>>Completed</option>
-            <option value="overdue" <?php echo ($data['task']['status'] === 'overdue') ? 'selected' : ''; ?>>Overdue</option>
-        </select>
-    </div>
-    <input type="hidden" name="document_id" value="<?php echo $data['task']['document_id']; ?>">
-    <button type="submit" class="w-full md:w-auto bg-neon-purple text-white hover:bg-purple-700 font-bold py-3 px-6 rounded transition-colors duration-300 ease-in-out transform hover:scale-105"><i class="fas fa-save mr-2"></i> Update Task</button>
-</form>
-<p class="mt-6"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $data['task']['document_id']; ?>" class="text-neon-purple hover:text-purple-400"><i class="fas fa-arrow-left mr-2"></i>Back to Tasks for Document</a></p>
-<?php else: ?>
-    <p class="text-red-400">Task not found.</p>
-    <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>index.php?url=accreditation/index">Go to Accreditation Processes</a></p>
-<?php endif; ?>
+    <?php else: ?>
+        <p class="text-red-600 text-center">Task not found.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Go to Accreditation Processes</a></p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/tasks/list_by_document.php
+++ b/app/views/tasks/list_by_document.php
@@ -1,93 +1,95 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
+<div class="container mx-auto px-4 py-8">
+    <?php if (isset($data['document'])): ?>
+        <div class="flex justify-between items-center mb-6">
+            <h2 class="text-2xl font-bold text-black">Tasks for Document: <?php echo htmlspecialchars($data['document']['name']); ?></h2>
+            <?php if (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
+                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/showCreateForm/<?php echo $data['document']['id']; ?>" class="bg-black text-white px-4 py-2 rounded hover:bg-gray-800 focus:outline-none focus:shadow-outline"><i class="fas fa-plus-square mr-2"></i> Create New Task</a>
+            <?php endif; ?>
+        </div>
 
-<?php if (isset($data['document'])): ?>
-    <h2 class="text-3xl font-bold text-neon-purple mb-4">Tasks for Document: <span class="text-gray-200"><?php echo htmlspecialchars($data['document']['name']); ?></span></h2>
-
-    <?php if (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
-        <p class="mb-6"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/showCreateForm/<?php echo $data['document']['id']; ?>" class="inline-block bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors duration-300"><i class="fas fa-plus-square mr-2"></i> Create New Task</a></p>
-    <?php endif; ?>
-
-    <?php if (isset($data['tasks']) && !empty($data['tasks'])): ?>
-        <ul class="space-y-4">
-            <?php foreach ($data['tasks'] as $task): ?>
-                <li id="task<?php echo $task['id'];?>" class="bg-brand-dark p-4 rounded-lg shadow hover:shadow-neon-purple/20 transition-shadow duration-300">
-                    <h4 class="text-xl font-semibold text-gray-200"><?php echo htmlspecialchars($task['description']); ?></h4>
-                    <div class="text-sm text-gray-400 mt-1">
-                        Status: <span class="task-status-text font-semibold <?php
-                            switch (strtolower($task['status'] ?? '')) {
-                                case 'completed': echo 'text-green-400'; break;
-                                case 'pending': echo 'text-yellow-400'; break;
-                                case 'in_progress': echo 'text-blue-400'; break;
-                                case 'overdue': echo 'text-red-400'; break;
-                                default: echo 'text-gray-400';
+        <?php if (isset($data['tasks']) && !empty($data['tasks'])): ?>
+            <ul class="space-y-4">
+                <?php foreach ($data['tasks'] as $task): ?>
+                    <li id="task<?php echo $task['id'];?>" class="bg-white border border-black p-4 rounded-lg shadow-md">
+                        <h4 class="text-xl font-semibold text-black"><?php echo htmlspecialchars($task['description']); ?></h4>
+                        <div class="text-sm text-black mt-1">
+                            Status: <span class="task-status-text font-semibold px-2 py-0.5 rounded-full text-xs <?php
+                                switch (strtolower($task['status'] ?? '')) {
+                                    case 'completed': echo 'bg-green-100 text-green-800 border border-green-400'; break;
+                                    case 'pending': echo 'bg-yellow-100 text-yellow-800 border border-yellow-400'; break;
+                                    case 'in_progress': echo 'bg-blue-100 text-blue-800 border border-blue-400'; break;
+                                    case 'overdue': echo 'bg-red-100 text-red-800 border border-red-400'; break;
+                                    default: echo 'bg-gray-100 text-gray-800 border border-gray-400';
+                                }
+                            ?>" id="task-status-<?php echo $task['id']; ?>"><?php echo htmlspecialchars(ucfirst($task['status'])); ?></span> |
+                            Due Date: <?php echo htmlspecialchars($task['due_date'] ? date('M d, Y', strtotime($task['due_date'])) : 'N/A'); ?> |
+                            Created by: <?php echo htmlspecialchars($task['created_by_name'] ?? 'N/A'); ?>
+                        </div>
+                        <?php if (!empty($task['assigned_users'])): ?>
+                            <p class="text-sm text-gray-700 mt-1">Assigned to:
+                            <?php
+                            $user_names = [];
+                            foreach ($task['assigned_users'] as $assigned_user) {
+                                $user_names[] = htmlspecialchars($assigned_user['name']);
                             }
-                        ?>" id="task-status-<?php echo $task['id']; ?>"><?php echo htmlspecialchars(ucfirst($task['status'])); ?></span> |
-                        Due Date: <?php echo htmlspecialchars($task['due_date'] ?? 'N/A'); ?> |
-                        Created by: <?php echo htmlspecialchars($task['created_by_name'] ?? 'N/A'); ?>
-                    </div>
-                    <?php if (!empty($task['assigned_users'])): ?>
-                        <p class="text-sm text-gray-500 mt-1">Assigned to:
-                        <?php
-                        $user_names = [];
-                        foreach ($task['assigned_users'] as $assigned_user) {
-                            $user_names[] = htmlspecialchars($assigned_user['name']);
-                        }
-                        echo implode(', ', $user_names);
-                        ?>
-                        </p>
-                    <?php else: ?>
-                        <p class="text-sm text-gray-500 mt-1"><em>Not assigned</em></p>
-                    <?php endif; ?>
-
-                    <div class="mt-3 space-x-3 text-sm">
-                        <?php if (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
-                            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/showEditForm/<?php echo $task['id']; ?>" class="text-yellow-400 hover:text-yellow-300"><i class="fas fa-edit mr-1"></i> Edit</a>
-                            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/showAssignForm/<?php echo $task['id']; ?>" class="text-blue-400 hover:text-blue-300"><i class="fas fa-user-plus mr-1"></i> Assign</a>
-                            <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/delete/<?php echo $task['id']; ?>/<?php echo $data['document']['id']; ?>" data-message="Are you sure you want to delete this task?" class="delete-confirm-link text-red-400 hover:text-red-300"><i class="fas fa-trash mr-1"></i> Delete</a>
+                            echo implode(', ', $user_names);
+                            ?>
+                            </p>
+                        <?php else: ?>
+                            <p class="text-sm text-gray-700 mt-1"><em>Not assigned</em></p>
                         <?php endif; ?>
 
-                        <?php
-                        $canUpdate = (isset($task['is_assigned_to_current_user']) && $task['is_assigned_to_current_user']) || (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser');
-                        ?>
-                        <?php if ($canUpdate): ?>
-                            <?php if ($task['status'] !== 'completed'): ?>
-                                <a href="#" class="ajax-update-task-status text-green-400 hover:text-green-300"
-                                   data-task-id="<?php echo $task['id']; ?>"
-                                   data-new-status="completed"
-                                   data-context-id="<?php echo $data['document']['id']; ?>"
-                                   data-redirect-context="document"
-                                   id="update-link-task-<?php echo $task['id']; ?>-completed"><i class="fas fa-check-circle mr-1"></i> Mark Completed</a>
+                        <div class="mt-3 space-x-3 text-sm">
+                            <?php if (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
+                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/showEditForm/<?php echo $task['id']; ?>" class="text-black hover:underline"><i class="fas fa-edit mr-1"></i> Edit</a>
+                                <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/showAssignForm/<?php echo $task['id']; ?>" class="text-black hover:underline"><i class="fas fa-user-plus mr-1"></i> Assign</a>
+                                <a href="#" data-href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/delete/<?php echo $task['id']; ?>/<?php echo $data['document']['id']; ?>" data-message="Are you sure you want to delete this task?" class="delete-confirm-link text-red-600 hover:text-red-800 underline"><i class="fas fa-trash mr-1"></i> Delete</a>
                             <?php endif; ?>
-                            <?php if ($task['status'] === 'completed' || $task['status'] === 'overdue' || $task['status'] === 'in_progress'): ?>
-                                <a href="#" class="ajax-update-task-status text-gray-400 hover:text-gray-300"
-                                   data-task-id="<?php echo $task['id']; ?>"
-                                   data-new-status="pending"
-                                   data-context-id="<?php echo $data['document']['id']; ?>"
-                                   data-redirect-context="document"
-                                   id="update-link-task-<?php echo $task['id']; ?>-pending"><i class="fas fa-clock mr-1"></i> Mark Pending</a>
+
+                            <?php
+                            $canUpdate = (isset($task['is_assigned_to_current_user']) && $task['is_assigned_to_current_user']) || (isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser');
+                            ?>
+                            <?php if ($canUpdate): ?>
+                                <?php if ($task['status'] !== 'completed'): ?>
+                                    <a href="#" class="ajax-update-task-status text-green-600 hover:text-green-800 hover:underline"
+                                       data-task-id="<?php echo $task['id']; ?>"
+                                       data-new-status="completed"
+                                       data-context-id="<?php echo $data['document']['id']; ?>"
+                                       data-redirect-context="document"
+                                       id="update-link-task-<?php echo $task['id']; ?>-completed"><i class="fas fa-check-circle mr-1"></i> Mark Completed</a>
+                                <?php endif; ?>
+                                <?php if ($task['status'] === 'completed' || $task['status'] === 'overdue' || $task['status'] === 'in_progress'): ?>
+                                    <a href="#" class="ajax-update-task-status text-gray-600 hover:text-gray-800 hover:underline"
+                                       data-task-id="<?php echo $task['id']; ?>"
+                                       data-new-status="pending"
+                                       data-context-id="<?php echo $data['document']['id']; ?>"
+                                       data-redirect-context="document"
+                                       id="update-link-task-<?php echo $task['id']; ?>-pending"><i class="fas fa-clock mr-1"></i> Mark Pending</a>
+                                <?php endif; ?>
+                                 <?php if ($task['status'] === 'pending'): ?>
+                                    <a href="#" class="ajax-update-task-status text-blue-600 hover:text-blue-800 hover:underline"
+                                       data-task-id="<?php echo $task['id']; ?>"
+                                       data-new-status="in_progress"
+                                       data-context-id="<?php echo $data['document']['id']; ?>"
+                                       data-redirect-context="document"
+                                       id="update-link-task-<?php echo $task['id']; ?>-inprogress"><i class="fas fa-spinner mr-1"></i> Mark In Progress</a>
+                                <?php endif; ?>
                             <?php endif; ?>
-                             <?php if ($task['status'] === 'pending'): ?>
-                                <a href="#" class="ajax-update-task-status text-orange-400 hover:text-orange-300"
-                                   data-task-id="<?php echo $task['id']; ?>"
-                                   data-new-status="in_progress"
-                                   data-context-id="<?php echo $data['document']['id']; ?>"
-                                   data-redirect-context="document"
-                                   id="update-link-task-<?php echo $task['id']; ?>-inprogress"><i class="fas fa-spinner mr-1"></i> Mark In Progress</a>
-                            <?php endif; ?>
-                        <?php endif; ?>
-                        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/showByEntity/task/<?php echo $task['id']; ?>" class="text-gray-500 hover:text-gray-300"><i class="fas fa-comment mr-1"></i> Comments</a>
-                    </div>
-                </li>
-            <?php endforeach; ?>
-        </ul>
+                            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/showByEntity/task/<?php echo $task['id']; ?>" class="text-black hover:underline"><i class="fas fa-comment mr-1"></i> Comments</a>
+                        </div>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else: ?>
+            <p class="text-black">No tasks found for this document.</p>
+        <?php endif; ?>
+
+        <p class="mt-8"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $data['document']['accreditation_process_id']; ?>" class="text-black hover:underline font-semibold"><i class="fas fa-arrow-left mr-2"></i>Back to Process Details</a></p>
+
     <?php else: ?>
-        <p class="text-gray-400">No tasks found for this document.</p>
+        <p class="text-red-600 text-center">Document information not found.</p>
+        <p class="text-center mt-2"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index" class="text-black hover:underline">Go to Accreditation Processes</a></p>
     <?php endif; ?>
-
-    <p class="mt-6"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $data['document']['accreditation_process_id']; ?>" class="text-neon-purple hover:text-purple-400 font-semibold"><i class="fas fa-arrow-left mr-2"></i>Back to Process Details</a></p>
-
-<?php else: ?>
-    <p class="text-red-400">Document information not found.</p>
-    <p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/index">Go to Accreditation Processes</a></p>
-<?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/tasks/my_tasks.php
+++ b/app/views/tasks/my_tasks.php
@@ -1,44 +1,63 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2>My Assigned Tasks</h2>
-<?php if (isset($data['tasks']) && !empty($data['tasks'])): ?>
-    <ul>
-        <?php foreach ($data['tasks'] as $task): ?>
-            <li>
-                <strong>Process:</strong> <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $task['accreditation_process_id']; ?>"><?php echo htmlspecialchars($task['process_title']); ?></a><br>
-                <strong>Document:</strong> <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $task['accreditation_process_id']; ?>#doc<?php echo $task['document_id'];?>"><?php echo htmlspecialchars($task['document_name']); ?></a>
-                 ( <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $task['document_id']; ?>#task<?php echo $task['id'];?>">View all tasks for this doc</a> )<br>
-                <strong>Task:</strong> <?php echo htmlspecialchars($task['description']); ?><br>
-                Status: <span class="task-status-text" id="task-status-<?php echo $task['id']; ?>"><?php echo htmlspecialchars($task['status']); ?></span><br>
-                Due Date: <?php echo htmlspecialchars($task['due_date'] ?? 'N/A'); ?><br>
-                <?php if ($task['status'] !== 'completed'): ?>
-                    <a href="#" class="ajax-update-task-status"
-                       data-task-id="<?php echo $task['id']; ?>"
-                       data-new-status="completed"
-                       data-context-id="<?php echo $_SESSION['user_id']; ?>"
-                       data-redirect-context="mytasks"
-                       id="update-link-task-<?php echo $task['id']; ?>-completed">Mark as Completed</a> |
-                <?php else: ?>
-                    <a href="#" class="ajax-update-task-status"
-                       data-task-id="<?php echo $task['id']; ?>"
-                       data-new-status="pending"
-                       data-context-id="<?php echo $_SESSION['user_id']; ?>"
-                       data-redirect-context="mytasks"
-                       id="update-link-task-<?php echo $task['id']; ?>-pending">Mark as Pending</a> |
-                <?php endif; ?>
-                 <?php if ($task['status'] === 'pending'): ?>
-                    <a href="#" class="ajax-update-task-status"
-                       data-task-id="<?php echo $task['id']; ?>"
-                       data-new-status="in_progress"
-                       data-context-id="<?php echo $_SESSION['user_id']; ?>"
-                       data-redirect-context="mytasks"
-                       id="update-link-task-<?php echo $task['id']; ?>-inprogress">Mark In Progress</a> |
-                <?php endif; ?>
-                 <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/showByEntity/task/<?php echo $task['id']; ?>">Comments</a>
-            </li>
-            <br>
-        <?php endforeach; ?>
-    </ul>
-<?php else: ?>
-    <p>You have no tasks assigned to you.</p>
-<?php endif; ?>
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-2xl font-bold text-black mb-6">My Assigned Tasks</h2>
+    <?php if (isset($data['tasks']) && !empty($data['tasks'])): ?>
+        <ul class="space-y-4">
+            <?php foreach ($data['tasks'] as $task): ?>
+                <li id="task<?php echo $task['id'];?>" class="bg-white border border-black p-4 rounded-lg shadow-md">
+                    <h4 class="text-lg font-semibold text-black"><?php echo htmlspecialchars($task['description']); ?></h4>
+                    <p class="text-sm text-black mt-1">
+                        <strong>Process:</strong> <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $task['accreditation_process_id']; ?>" class="text-black hover:underline"><?php echo htmlspecialchars($task['process_title']); ?></a>
+                    </p>
+                    <p class="text-sm text-black">
+                        <strong>Document:</strong> <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>accreditation/show/<?php echo $task['accreditation_process_id']; ?>#doc<?php echo $task['document_id'];?>" class="text-black hover:underline"><?php echo htmlspecialchars($task['document_name']); ?></a>
+                        ( <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>task/listByDocument/<?php echo $task['document_id']; ?>#task<?php echo $task['id'];?>" class="text-black hover:underline">View all tasks for this doc</a> )
+                    </p>
+                    <div class="text-sm text-black mt-1">
+                        Status: <span class="task-status-text font-semibold px-2 py-0.5 rounded-full text-xs <?php
+                            switch (strtolower($task['status'] ?? '')) {
+                                case 'completed': echo 'bg-green-100 text-green-800 border border-green-400'; break;
+                                case 'pending': echo 'bg-yellow-100 text-yellow-800 border border-yellow-400'; break;
+                                case 'in_progress': echo 'bg-blue-100 text-blue-800 border border-blue-400'; break;
+                                case 'overdue': echo 'bg-red-100 text-red-800 border border-red-400'; break;
+                                default: echo 'bg-gray-100 text-gray-800 border border-gray-400';
+                            }
+                        ?>" id="task-status-<?php echo $task['id']; ?>"><?php echo htmlspecialchars(ucfirst($task['status'])); ?></span> |
+                        Due Date: <?php echo htmlspecialchars($task['due_date'] ? date('M d, Y', strtotime($task['due_date'])) : 'N/A'); ?>
+                    </div>
+
+                    <div class="mt-3 space-x-3 text-sm">
+                        <?php if ($task['status'] !== 'completed'): ?>
+                            <a href="#" class="ajax-update-task-status text-green-600 hover:text-green-800 hover:underline"
+                               data-task-id="<?php echo $task['id']; ?>"
+                               data-new-status="completed"
+                               data-context-id="<?php echo $_SESSION['user_id']; ?>"
+                               data-redirect-context="mytasks"
+                               id="update-link-task-<?php echo $task['id']; ?>-completed"><i class="fas fa-check-circle mr-1"></i> Mark Completed</a>
+                        <?php endif; ?>
+                        <?php if ($task['status'] === 'completed' || $task['status'] === 'overdue' || $task['status'] === 'in_progress'): ?>
+                            <a href="#" class="ajax-update-task-status text-gray-600 hover:text-gray-800 hover:underline"
+                               data-task-id="<?php echo $task['id']; ?>"
+                               data-new-status="pending"
+                               data-context-id="<?php echo $_SESSION['user_id']; ?>"
+                               data-redirect-context="mytasks"
+                               id="update-link-task-<?php echo $task['id']; ?>-pending"><i class="fas fa-clock mr-1"></i> Mark Pending</a>
+                        <?php endif; ?>
+                         <?php if ($task['status'] === 'pending'): ?>
+                            <a href="#" class="ajax-update-task-status text-blue-600 hover:text-blue-800 hover:underline"
+                               data-task-id="<?php echo $task['id']; ?>"
+                               data-new-status="in_progress"
+                               data-context-id="<?php echo $_SESSION['user_id']; ?>"
+                               data-redirect-context="mytasks"
+                               id="update-link-task-<?php echo $task['id']; ?>-inprogress"><i class="fas fa-spinner mr-1"></i> Mark In Progress</a>
+                        <?php endif; ?>
+                         <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>comment/showByEntity/task/<?php echo $task['id']; ?>" class="text-black hover:underline"><i class="fas fa-comment mr-1"></i> Comments</a>
+                    </div>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php else: ?>
+        <p class="text-black">You have no tasks assigned to you.</p>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/users/list.php
+++ b/app/views/users/list.php
@@ -1,20 +1,43 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2 class="text-3xl font-bold text-neon-purple mb-6">User List</h2>
-<?php if (isset($data['users']) && !empty($data['users'])): ?>
-    <ul class="space-y-3">
-        <?php foreach ($data['users'] as $user_item): ?>
-            <li class="bg-brand-dark p-4 rounded-lg shadow">
-                <p class="text-lg font-semibold text-gray-200"><?php echo htmlspecialchars($user_item['name']); ?></p>
-                <p class="text-sm text-gray-400"><?php echo htmlspecialchars($user_item['email']); ?></p>
-                <p class="text-sm text-gray-500 mt-1">Role: <span class="font-medium text-gray-300"><?php echo htmlspecialchars(ucfirst($user_item['role'])); ?></span></p>
-                <!-- Add edit/delete links here if needed later and if superuser -->
-            </li>
-        <?php endforeach; ?>
-    </ul>
-<?php else: ?>
-    <p class="text-gray-400">No users found.</p>
-<?php endif; ?>
-<?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
-    <p class="mt-6"><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showRegistrationForm" class="inline-block bg-neon-purple text-white hover:bg-purple-700 font-bold py-2 px-4 rounded transition-colors duration-300"><i class="fas fa-user-plus mr-2"></i> Add New User</a></p>
-<?php endif; ?>
+<div class="container mx-auto px-4 py-8">
+    <div class="flex justify-between items-center mb-6">
+        <h2 class="text-2xl font-bold text-black">User List</h2>
+        <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'superuser'): ?>
+            <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/showRegistrationForm" class="inline-block bg-black text-white hover:bg-gray-800 font-bold py-2 px-4 rounded"><i class="fas fa-user-plus mr-2"></i> Add New User</a>
+        <?php endif; ?>
+    </div>
+
+    <?php if (isset($data['users']) && !empty($data['users'])): ?>
+        <div class="overflow-x-auto">
+            <table class="min-w-full bg-white border border-black rounded-lg shadow-md">
+                <thead class="bg-black text-white">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Name</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Email</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Role</th>
+                        <!-- <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Actions</th> -->
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    <?php foreach ($data['users'] as $user_item): ?>
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black border-b border-gray-200"><?php echo htmlspecialchars($user_item['name']); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black border-b border-gray-200"><?php echo htmlspecialchars($user_item['email']); ?></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-black border-b border-gray-200"><?php echo htmlspecialchars(ucfirst($user_item['role'])); ?></td>
+                            <!-- Future actions could go here, e.g., edit user link -->
+                            <!-- <td class="px-6 py-4 whitespace-nowrap text-sm text-black border-b border-gray-200">
+                                <a href="#" class="text-black hover:underline">Edit</a>
+                            </td> -->
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php else: ?>
+        <p class="text-black">No users found.</p>
+        <?php if (isset($_SESSION['user_id']) && isset($_SESSION['user_role']) && $_SESSION['user_role'] !== 'superuser'): ?>
+             <p class="text-black mt-4">User list is only available to superusers.</p>
+        <?php endif; ?>
+    <?php endif; ?>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/app/views/users/profile.php
+++ b/app/views/users/profile.php
@@ -1,11 +1,27 @@
 <?php require_once __DIR__ . '/../layouts/header.php'; ?>
-<h2>User Profile</h2>
-<?php if (isset($data['user'])): ?>
-    <p><strong>Name:</strong> <?php echo htmlspecialchars($data['user']['name']); ?></p>
-    <p><strong>Email:</strong> <?php echo htmlspecialchars($data['user']['email']); ?></p>
-    <p><strong>Role:</strong> <?php echo htmlspecialchars($data['user']['role']); ?></p>
-<?php else: ?>
-    <p>User information not found.</p>
-<?php endif; ?>
-<p><a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/logout">Logout</a></p>
+<div class="container mx-auto px-4 py-8">
+    <h2 class="text-2xl font-bold text-black mb-6 text-center">User Profile</h2>
+    <?php if (isset($data['user'])): ?>
+        <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 border border-black w-full max-w-lg mx-auto">
+            <div class="mb-4">
+                <p class="text-sm font-semibold text-black mb-1">Name:</p>
+                <p class="text-lg text-black"><?php echo htmlspecialchars($data['user']['name']); ?></p>
+            </div>
+            <div class="mb-4">
+                <p class="text-sm font-semibold text-black mb-1">Email:</p>
+                <p class="text-lg text-black"><?php echo htmlspecialchars($data['user']['email']); ?></p>
+            </div>
+            <div class="mb-4">
+                <p class="text-sm font-semibold text-black mb-1">Role:</p>
+                <p class="text-lg text-black"><?php echo htmlspecialchars(ucfirst($data['user']['role'])); ?></p>
+            </div>
+            <!-- Add other profile information or actions here -->
+        </div>
+    <?php else: ?>
+        <p class="text-black text-center">User information not found.</p>
+    <?php endif; ?>
+    <p class="text-center mt-6">
+        <a href="<?php echo htmlspecialchars($APP_BASE_URL); ?>user/logout" class="text-black hover:underline">Logout</a>
+    </p>
+</div>
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/public/css/input.css
+++ b/public/css/input.css
@@ -4,7 +4,6 @@
 
 /* You can add custom base styles or component classes here later if needed */
 body {
-  @apply bg-brand-dark text-gray-300; /* Main dark background and default light text */
-  /* Add any other global base styles here, e.g., font family if desired */
-  /* font-family: 'Inter', sans-serif; (ensure font is imported if using custom) */
+  @apply bg-white text-black;
+  /* Add any other global base styles here */
 }


### PR DESCRIPTION
This commit introduces a major UI overhaul, changing the application theme to a consistent black and white scheme using Tailwind CSS.

Key changes include:
- Updated `public/css/input.css` to set the default body background to white and text to black.
- Systematically refactored all PHP view files in `app/views/` (layouts, auth, home, accreditations, documents, document_templates, tasks, users, comments) to use Tailwind utility classes that adhere to the new black and white theme.
- Standardized styling for:
    - Page layouts and containers
    - Typography (headings, paragraphs, links)
    - Forms (inputs, labels, buttons)
    - Tables
    - Navigation (header, footer)
    - Status indicators and alert messages (maintaining semantic colors for alerts and specific status badges for clarity).
- Removed old theme-specific classes and inline styles (e.g., `neon-purple`, `brand-dark`).
- Ensured that dynamically generated content (like forms from templates and comment lists) also conforms to the new theme.

The goal was to create a clean, consistent, and more accessible user interface. The Tailwind CSS build process (`npx tailwindcss -i ./public/css/input.css -o ./public/css/style.css --minify`) must be run to see these changes take effect.